### PR TITLE
Change AIModelRequestBus.h file path in .cmake

### DIFF
--- a/Code/genaiframework_api_files.cmake
+++ b/Code/genaiframework_api_files.cmake
@@ -1,10 +1,10 @@
 set(FILES
     Include/GenAIFramework/AIContext.h
     Include/GenAIFramework/Communication/AIServiceRequesterBus.h
+    Include/GenAIFramework/Communication/AIServiceRequesterBus.h
     Include/GenAIFramework/GenAIFrameworkActionBus.h
     Include/GenAIFramework/GenAIFrameworkBus.h
     Include/GenAIFramework/GenAIFrameworkScriptExecutor.h
     Include/GenAIFramework/GenAIFrameworkTypeIds.h
-    Include/GenAIFramework/ModelConfiguration/AIModelRequestBus.h
     Include/GenAIFramework/SystemRegistrationContext/GenAIFrameworkSystemRegistrationContext.h
 )


### PR DESCRIPTION
The `AIModelRequestBus.h` file was moved and its path was not changed in `Code/genaiframework_api_files.cmake`