### PR TITLE
Fix no registered owning instance warning

### DIFF
--- a/Code/Include/GenAIFramework/AIComponentBase/AIComponentBase.h
+++ b/Code/Include/GenAIFramework/AIComponentBase/AIComponentBase.h
@@ -33,8 +33,8 @@ namespace GenAIFramework
         void Deactivate() override;
 
     protected:
-        AZStd::string m_selectedServiceRequestorName;
-        AZStd::string m_selectedModelConfigurationName;
+        AZStd::string m_selectedServiceRequestorName = "";
+        AZStd::string m_selectedModelConfigurationName = "";
 
         AZ::EntityId m_selectedServiceRequestorId;
         AZ::EntityId m_selectedModelConfigurationId;

--- a/Code/Source/AIComponentBase/AIComponentBase.cpp
+++ b/Code/Source/AIComponentBase/AIComponentBase.cpp
@@ -48,6 +48,8 @@ namespace GenAIFramework
 
     void AIComponentBase::Activate()
     {
+        UpdateNamedServiceRequestorId();
+        UpdateNamedModelConfigurationId();
     }
 
     void AIComponentBase::Deactivate()


### PR DESCRIPTION
Fix #27

I've fixed the issue by removing the entityId serialization.

I have not found any other method of fixing this error as the AI system entities are created differently from Game/Editor entities.
I've also tested the System Entity and it is also not registered (and has no owning instance).