### PR TITLE
Small UI fixes 

### DIFF
--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponent.cpp
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponent.cpp
@@ -125,13 +125,13 @@ namespace GenAIFramework
     AZStd::vector<AZStd::pair<AZStd::string, AZ::Uuid>> GenAIFrameworkSystemComponent::
         GetRegisteredModelConfigurationsNameAndComponentTypeId()
     {
-        auto modelConfigurations = GetSystemRegistrationContext()->GetRegisteredModelConfigurations();
+        const auto modelConfigurations = GetSystemRegistrationContext()->GetRegisteredModelConfigurations();
         return GetRegisteredComponentsNameAndComponentTypeId(modelConfigurations);
     }
 
     AZStd::vector<AZStd::pair<AZStd::string, AZ::Uuid>> GenAIFrameworkSystemComponent::GetRegisteredServiceProvidersNameAndComponentTypeId()
     {
-        auto registeredProviders = GetSystemRegistrationContext()->GetRegisteredServiceProviders();
+        const auto registeredProviders = GetSystemRegistrationContext()->GetRegisteredServiceProviders();
         return GetRegisteredComponentsNameAndComponentTypeId(registeredProviders);
     }
 

--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponentConfiguration.h
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponentConfiguration.h
@@ -8,9 +8,7 @@
 
 #pragma once
 
-#include "AzCore/std/smart_ptr/shared_ptr.h"
 #include <AzCore/Component/Entity.h>
-#include <AzCore/Memory/Memory_fwd.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/Serialization/SerializeContext.h>
 

--- a/Gems/GenAIFramework/Code/Source/Test/GenAIFrameworkTestEditorComponent.cpp
+++ b/Gems/GenAIFramework/Code/Source/Test/GenAIFrameworkTestEditorComponent.cpp
@@ -47,7 +47,7 @@ namespace GenAIFramework
 
             if (AZ::EditContext* ec = serializeContext->GetEditContext())
             {
-                ec->Class<GenAIFrameworkTestEditorComponent>("Test Editor Component", "Simple test of AI")
+                ec->Class<GenAIFrameworkTestEditorComponent>("Test AI API Component", "Simple test of AI")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
                     ->Attribute(AZ::Edit::Attributes::Category, "AI")

--- a/Gems/GenAIFramework/Code/Source/UI/GenAIFrameworkWidget.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/GenAIFrameworkWidget.cpp
@@ -28,13 +28,13 @@ namespace GenAIFramework
         {
             AZStd::vector<AZ::Component*> activeModelConfigurations = interface->GetActiveModelConfigurations();
             m_newModelConfigurationSegment = new NewModelConfigurationSegment();
-            m_modelsConfigurationTab = new Tab(activeModelConfigurations, m_newModelConfigurationSegment, "Model configurations", m_tabs);
-            m_tabs->addTab(m_modelsConfigurationTab, "Model configurations");
+            m_modelsConfigurationTab = new Tab(activeModelConfigurations, m_newModelConfigurationSegment, "Model Configurations", m_tabs);
+            m_tabs->addTab(m_modelsConfigurationTab, "Model Configurations");
 
             AZStd::vector<AZ::Component*> activeProviders = interface->GetActiveServiceProviders();
             m_newServiceProviderSegment = new NewServiceProviderSegment();
-            m_serviceProvidersTab = new Tab(activeProviders, m_newServiceProviderSegment, "AI service providers", m_tabs);
-            m_tabs->addTab(m_serviceProvidersTab, "AI service providers");
+            m_serviceProvidersTab = new Tab(activeProviders, m_newServiceProviderSegment, "AI Service Providers", m_tabs);
+            m_tabs->addTab(m_serviceProvidersTab, "AI Service Providers");
         }
 
         verticalLayout->addWidget(m_tabs);

--- a/Gems/GenAIFramework/Code/Source/UI/NewSegment.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/NewSegment.cpp
@@ -45,15 +45,10 @@ namespace GenAIFramework
 
     void NewSegment::onCreateButtonPressed()
     {
-        QMessageBox::StandardButton reply;
-        reply = QMessageBox::question(this, "Confirmation", "Are you sure?", QMessageBox::Yes | QMessageBox::No);
-        if (reply == QMessageBox::Yes)
-        {
-            AZ::Uuid selectedComponentTypeId = m_componentSelection->currentData().value<AZ::Uuid>();
-            AZStd::string name = m_nameInput->text().toUtf8().constData();
-            AZ::Component* component = CreateNewComponentEntity(name, selectedComponentTypeId);
-            emit NewComponentAdded(component, selectedComponentTypeId);
-        }
+        AZ::Uuid selectedComponentTypeId = m_componentSelection->currentData().value<AZ::Uuid>();
+        AZStd::string name = m_nameInput->text().toUtf8().constData();
+        AZ::Component* component = CreateNewComponentEntity(name, selectedComponentTypeId);
+        emit NewComponentAdded(component, selectedComponentTypeId);
     }
 
 } // namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Source/UI/Segment.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/Segment.cpp
@@ -28,12 +28,16 @@ namespace GenAIFramework
         AZ::ComponentApplicationBus::BroadcastResult(m_serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
         AZ_Assert(m_serializeContext, "Failed to retrieve serialize context.");
 
+	const AZStd::string name = component->GetNamedEntityId().GetName();
+        m_componentName = new QLabel(name.c_str());
+
         const int propertyLabelWidth = 250;
         m_propertyEditor = new AzToolsFramework::ReflectedPropertyEditor(this);
         m_propertyEditor->Setup(m_serializeContext, this, true, propertyLabelWidth);
         m_propertyEditor->show();
         m_propertyEditor->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Maximum);
         m_propertyEditor->SetAutoResizeLabels(true);
+        m_propertyEditor->SetHideRootProperties(true);
 
         blockSignals(true);
         m_propertyEditor->ClearInstances();
@@ -45,6 +49,7 @@ namespace GenAIFramework
         m_removeButton->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
         connect(m_removeButton, &QPushButton::clicked, this, &Segment::onRemoveButtonPressed);
 
+        m_verticalLayout->addWidget(m_componentName);
         m_verticalLayout->addWidget(m_propertyEditor);
         m_verticalLayout->addWidget(m_removeButton);
 

--- a/Gems/GenAIFramework/Code/Source/UI/Segment.h
+++ b/Gems/GenAIFramework/Code/Source/UI/Segment.h
@@ -14,6 +14,7 @@
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Math/Uuid.h>
 #include <QBoxLayout>
+#include <QLabel>
 #include <QPushButton>
 #include <QWidget>
 #include <UI/PropertyEditor/ReflectedPropertyEditor.hxx>
@@ -49,6 +50,7 @@ namespace GenAIFramework
         AzToolsFramework::ReflectedPropertyEditor* m_propertyEditor;
         AZ::Component* m_component;
         QPushButton* m_removeButton;
+        QLabel* m_componentName;
     };
 
 } // namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Source/UI/Tab.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/Tab.cpp
@@ -44,7 +44,7 @@ namespace GenAIFramework
     {
         Segment* segment = new Segment(component, componentTypeId, m_segmentControl);
         m_segments.push_back(segment);
-        AZStd::string name = component->GetNamedEntityId().GetName();
+        const AZStd::string name = component->GetNamedEntityId().GetName();
         m_segmentControl->addTab(segment, QString(name.c_str()));
         connect(segment, &Segment::RemoveSegment, this, &Tab::RemoveSegment);
     }


### PR DESCRIPTION
Closes #32 

This PR removes "Are you sure?" confirmation when creating a new service provider or model confirmation (remains for removing any of the two) and adds auto expand property for parameters with a walkaround (added name of the entity separately).