### PR TITLE
Add registered name getter for async python requests

### DIFF
--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AsyncRequestBus.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AsyncRequestBus.h
@@ -63,11 +63,11 @@ namespace GenAIFramework
 
         //! Get the registered name of the active model configuration.
         //! @return The registered name of the active model configuration or an empty string if not set.
-        virtual AZStd::string GetActiveModelConfigurationRegisteredName() = 0;
+        virtual AZStd::string GetModelConfigurationTypename() = 0;
 
         //! Get the registered name of the active service provider.
         //! @return The registered name of the active service provider or an empty string if not set.
-        virtual AZStd::string GetActiveServiceProviderRegisteredName() = 0;
+        virtual AZStd::string GetServiceProviderTypename() = 0;
 
         //! Reset the history of the currently selected model.
         virtual void ResetModelHistory() = 0;

--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIAsyncRequestSystemComponent.cpp
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIAsyncRequestSystemComponent.cpp
@@ -40,8 +40,8 @@ namespace GenAIFramework
                 ->Event("GetResponse", &AsyncRequestBus::Events::GetResponse)
                 ->Event("ResetModelHistory", &AsyncRequestBus::Events::ResetModelHistory)
                 ->Event("EnableModelHistory", &AsyncRequestBus::Events::EnableModelHistory)
-                ->Event("GetActiveModelConfigurationRegisteredName", &AsyncRequestBus::Events::GetActiveModelConfigurationRegisteredName)
-                ->Event("GetActiveServiceProviderRegisteredName", &AsyncRequestBus::Events::GetActiveServiceProviderRegisteredName);
+                ->Event("GetModelConfigurationTypename", &AsyncRequestBus::Events::GetModelConfigurationTypename)
+                ->Event("GetServiceProviderTypename", &AsyncRequestBus::Events::GetServiceProviderTypename);
         }
     }
 
@@ -258,7 +258,7 @@ namespace GenAIFramework
             m_modelConfigurationId, &GenAIFramework::AIModelRequestBus::Events::EnableModelHistory, enableHistory);
     }
 
-    AZStd::string GenAIAsyncRequestSystemComponent::GetActiveComponentRegisteredName(
+    AZStd::string GenAIAsyncRequestSystemComponent::GetComponentTypename(
         const AZStd::vector<AZStd::pair<AZStd::string, AZ::Uuid>>& registeredComponents, const AZ::EntityId& entityId)
     {
         if (!entityId.IsValid())
@@ -282,6 +282,7 @@ namespace GenAIFramework
 
         for (const auto& [name, typeId] : registeredComponents)
         {
+            // The amount of components in the entity is only one. So this loop will run only once.
             for (const auto& component : entityComponents)
             {
                 if (typeId == component->RTTI_GetType())
@@ -299,15 +300,15 @@ namespace GenAIFramework
         return {};
     }
 
-    AZStd::string GenAIAsyncRequestSystemComponent::GetActiveModelConfigurationRegisteredName()
+    AZStd::string GenAIAsyncRequestSystemComponent::GetModelConfigurationTypename()
     {
-        return GetActiveComponentRegisteredName(
+        return GetComponentTypename(
             GenAIFrameworkInterface::Get()->GetModelConfigurationNamesAndComponentTypeIds(), m_modelConfigurationId);
     }
 
-    AZStd::string GenAIAsyncRequestSystemComponent::GetActiveServiceProviderRegisteredName()
+    AZStd::string GenAIAsyncRequestSystemComponent::GetServiceProviderTypename()
     {
-        return GetActiveComponentRegisteredName(
+        return GetComponentTypename(
             GenAIFrameworkInterface::Get()->GetServiceProviderNamesAndComponentTypeIds(), m_serviceProviderId);
     }
 

--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIAsyncRequestSystemComponent.h
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIAsyncRequestSystemComponent.h
@@ -49,12 +49,12 @@ namespace GenAIFramework
         AZ::Uuid SendPromptToLLM(const AZStd::string& prompt) override;
         bool IsResponseReady(AZ::Uuid promptId) override;
         AZStd::string GetResponse(AZ::Uuid promptId) override;
-        AZStd::string GetActiveModelConfigurationRegisteredName() override;
-        AZStd::string GetActiveServiceProviderRegisteredName() override;
+        AZStd::string GetModelConfigurationTypename() override;
+        AZStd::string GetServiceProviderTypename() override;
         void ResetModelHistory() override;
         void EnableModelHistory(bool enableHistory) override;
 
-        AZStd::string GetActiveComponentRegisteredName(
+        AZStd::string GetComponentTypename(
             const AZStd::vector<AZStd::pair<AZStd::string, AZ::Uuid>>& registeredComponents, const AZ::EntityId& entityId);
 
         bool SetEntityIdByName(const AZStd::vector<AZ::Component*>& components, const AZStd::string& entityName, AZ::EntityId& entityId);

--- a/Gems/GenAIFramework/README.md
+++ b/Gems/GenAIFramework/README.md
@@ -77,8 +77,8 @@ print(response)
 
 To get registered name of the currently used model configuration or service provider use:
 ```python
-registered_name = azlmbr.ai.asyncRequestBus(azlmbr.bus.Broadcast, "GetActiveModelConfigurationRegisteredName")
-registered_name = azlmbr.ai.asyncRequestBus(azlmbr.bus.Broadcast, "GetActiveServiceProviderRegisteredName")
+registered_name = azlmbr.ai.asyncRequestBus(azlmbr.bus.Broadcast, "GetModelConfigurationTypename")
+registered_name = azlmbr.ai.asyncRequestBus(azlmbr.bus.Broadcast, "GetServiceProviderTypename")
 ``` 
 
 To reset the model history, use the following code snippet:


### PR DESCRIPTION
I've added a getter for the registered name of the model configuration component currently used in the async python requests.
Example in readme.
Resolves #95.