### PR TITLE
Add request timeout for ollama

### DIFF
--- a/Gems/GenAIVendorBundle/Code/Source/Providers/Ollama/OllamaHttpProvider.h
+++ b/Gems/GenAIVendorBundle/Code/Source/Providers/Ollama/OllamaHttpProvider.h
@@ -27,6 +27,7 @@ namespace GenAIVendorBundle
 
         AZStd::string m_url = "";
         AZStd::string m_contentType = "application/json";
+        int m_timeout = 10000;
     };
 
     class OllamaHttpServiceComponent


### PR DESCRIPTION
I've added a request timeout for the Ollama model. This timeout is editable in the provider configuration.