### PR TITLE
UI/UX: fix NewChat, move configuration, improvements

### DIFF
--- a/Gems/GenAIFramework/Code/Source/UI/AIAssistantWidget.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/AIAssistantWidget.cpp
@@ -34,18 +34,11 @@ namespace GenAIFramework
     {
         m_ui->setupUi(this);
         m_agentConfigurationWidget = new AgentConfigurationWidget();
-        m_newChatWidget = new NewChatWidget();
+        m_newChatWidget = new NewChatWidget(m_agentConfigurationWidget);
 
-        connect(m_ui->actionConfigure, &QAction::triggered, this, &AIAssistantWidget::OnConfigureAction);
         connect(m_newChatWidget, &NewChatWidget::chatCreated, this, &AIAssistantWidget::OnChatCreated);
 
         m_ui->conversations->addTab(m_newChatWidget, "+");
-    }
-
-    void AIAssistantWidget::OnConfigureAction()
-    {
-        m_agentConfigurationWidget->resize(this->size());
-        m_agentConfigurationWidget->show();
     }
 
     void AIAssistantWidget::OnChatCreated(

--- a/Gems/GenAIFramework/Code/Source/UI/AIAssistantWidget.h
+++ b/Gems/GenAIFramework/Code/Source/UI/AIAssistantWidget.h
@@ -36,7 +36,6 @@ namespace GenAIFramework
         explicit AIAssistantWidget(QWidget* parent = nullptr);
 
     private slots:
-        void OnConfigureAction();
         void OnChatCreated(const QString& chatName, const QString& modelName, const QString& providerName, const QString& featureName);
         void OnChatClosed();
 

--- a/Gems/GenAIFramework/Code/Source/UI/AIAssistantWidget.ui
+++ b/Gems/GenAIFramework/Code/Source/UI/AIAssistantWidget.ui
@@ -13,25 +13,7 @@
   <property name="windowTitle">
    <string>MainWindow</string>
   </property>
-  <widget class="QTabWidget" name="conversations">
-  </widget>
-  <widget class="QMenuBar" name="menubar">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>660</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <widget class="QMenu" name="menuChats">
-    <property name="title">
-     <string>Model</string>
-    </property>
-    <addaction name="actionConfigure"/>
-   </widget>
-   <addaction name="menuChats"/>
-  </widget>
+  <widget class="QTabWidget" name="conversations"/>
   <widget class="QStatusBar" name="statusbar"/>
   <action name="actionNewChat">
    <property name="text">

--- a/Gems/GenAIFramework/Code/Source/UI/AIChatWidget.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/AIChatWidget.cpp
@@ -36,12 +36,11 @@ namespace GenAIFramework
     {
         m_ui->setupUi(this);
 
-        QString description = QString("Model: %1 Provider: %2").arg(modelName, providerName);
+        const QString description = QString("Feature: %1 Model: %2 Provider: %3").arg(featureName, modelName, providerName);
         m_ui->configDescription->setText(description);
 
         QStyle* style = qApp->style();
-        QIcon closeIcon = style->standardIcon(QStyle::SP_TitleBarCloseButton);
-        m_ui->closeButton->setIcon(closeIcon);
+        m_ui->closeButton->setIcon(style->standardIcon(QStyle::SP_TitleBarCloseButton));
 
         m_uiChatLayout = new QVBoxLayout();
         m_uiChatLayout->setAlignment(Qt::AlignBottom);

--- a/Gems/GenAIFramework/Code/Source/UI/AIChatWidget.ui
+++ b/Gems/GenAIFramework/Code/Source/UI/AIChatWidget.ui
@@ -33,8 +33,8 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>25</width>
-         <height>25</height>
+         <width>26</width>
+         <height>24</height>
         </size>
        </property>
        <property name="toolTip">
@@ -44,7 +44,7 @@
         <string/>
        </property>
        <property name="flat">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
       </widget>
      </item>

--- a/Gems/GenAIFramework/Code/Source/UI/AgentConfigurationWidget/AgentConfigurationWidget.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/AgentConfigurationWidget/AgentConfigurationWidget.cpp
@@ -40,6 +40,11 @@ namespace GenAIFramework
         verticalLayout->addWidget(m_tabs);
     }
 
+    void AgentConfigurationWidget::SetActiveTab(const int index)
+    {
+        m_tabs->setCurrentIndex(index);
+    }
+
     void AgentConfigurationWidget::closeEvent([[maybe_unused]] QCloseEvent* event)
     {
         this->hide();

--- a/Gems/GenAIFramework/Code/Source/UI/AgentConfigurationWidget/AgentConfigurationWidget.h
+++ b/Gems/GenAIFramework/Code/Source/UI/AgentConfigurationWidget/AgentConfigurationWidget.h
@@ -21,11 +21,21 @@
 
 namespace GenAIFramework
 {
+    namespace AgentConfiguration
+    {
+        enum class TabIndex : int
+        {
+            ModelsConfiguration = 0,
+            ProvidersConfiguration
+        };
+    }
+
     class AgentConfigurationWidget : public QWidget
     {
         Q_OBJECT
     public:
         explicit AgentConfigurationWidget(QWidget* parent = nullptr);
+        void SetActiveTab(const int index);
 
     protected:
         // QWidget overrides

--- a/Gems/GenAIFramework/Code/Source/UI/NewChatWidget.h
+++ b/Gems/GenAIFramework/Code/Source/UI/NewChatWidget.h
@@ -16,6 +16,7 @@
 
 #include <AzCore/Component/Entity.h>
 #include <GenAIFramework/GenAIFrameworkBus.h>
+#include <UI/AgentConfigurationWidget/AgentConfigurationWidget.h>
 
 #endif
 
@@ -32,7 +33,7 @@ namespace GenAIFramework
     {
         Q_OBJECT
     public:
-        explicit NewChatWidget(QWidget* parent = nullptr);
+        explicit NewChatWidget(AgentConfigurationWidget* agentConfigurationWidget, QWidget* parent = nullptr);
         void UpdateModelAndProviderLists();
         void UpdateFeaturesList();
         ~NewChatWidget() override;
@@ -44,6 +45,7 @@ namespace GenAIFramework
 
     private slots:
         void OnCreateButton();
+        void OnAgentConfigurationButton();
 
     protected:
         // QWidget overrides
@@ -65,6 +67,7 @@ namespace GenAIFramework
         void SetModelAndProvider(const QString& modelName, const QString& providerName);
 
         Ui::NewChatWidgetUI* m_ui;
+        AgentConfigurationWidget* m_agentConfigurationWidget;
 
         QMap<QString, AZ::EntityId> m_ServiceProviderNameToId;
         QMap<QString, AZ::EntityId> m_modelConfigurationNameToId;

--- a/Gems/GenAIFramework/Code/Source/UI/NewChatWidget.ui
+++ b/Gems/GenAIFramework/Code/Source/UI/NewChatWidget.ui
@@ -49,19 +49,57 @@
       <item>
        <widget class="QComboBox" name="models"/>
       </item>
+      <item>
+       <widget class="QPushButton" name="pushButtonModels">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>26</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
      </layout>
     </item>
     <item>
-     <layout class="QHBoxLayout" name="horizontalService">
+     <layout class="QHBoxLayout" name="horizontalProviders">
       <item>
-       <widget class="QLabel" name="labelService">
+       <widget class="QLabel" name="labelProvider">
         <property name="text">
-         <string>Service</string>
+         <string>Service Provider</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QComboBox" name="providers"/>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pushButtonProviders">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>26</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
       </item>
      </layout>
     </item>
@@ -75,7 +113,14 @@
        </widget>
       </item>
       <item>
-       <widget class="QComboBox" name="features"/>
+       <widget class="QComboBox" name="features">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
       </item>
      </layout>
     </item>


### PR DESCRIPTION
Bugfixes:
- the `NewChatWidget` widget was incorrectly creating new chats due to incorrect slots (the values were not set at the start, but only after changes), this part of the code was reworked
- the `AIAssistantWidget` was not informing the user about the selected feature in the chat window
- the UI objects were named incorrectly

Other changes:
- the configuration widget was moved from the _Menubar_ in `AIAssistantWidget` to buttons in the `NewChatWidget` (the _Menubar_ was completely removed)