### PR TITLE
Rename ChatFeature->O3DEAssistantFeature

### DIFF
--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponent.cpp
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponent.cpp
@@ -8,11 +8,11 @@
 
 #include "GenAIFrameworkSystemComponent.h"
 
-#include <ChatFeature/ChatFeature.h>
 #include <Clients/GenAIFrameworkSystemComponentConfiguration.h>
 #include <GenAIFramework/Feature/FeatureBase.h>
 #include <GenAIFramework/GenAIFrameworkTypeIds.h>
 #include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
+#include <O3DEAssistantFeature/O3DEAssistantFeature.h>
 
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
@@ -32,7 +32,7 @@ namespace GenAIFramework
         FeatureBase::Reflect(context);
         GenAIFrameworkSystemComponentConfiguration::Reflect(context);
 
-        ChatFeature::Reflect(context);
+        O3DEAssistantFeature::Reflect(context);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {

--- a/Gems/GenAIFramework/Code/Source/O3DEAssistantFeature/O3DEAssistantFeature.cpp
+++ b/Gems/GenAIFramework/Code/Source/O3DEAssistantFeature/O3DEAssistantFeature.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include "ChatFeature.h"
+#include "O3DEAssistantFeature.h"
 
 #include <AzCore/std/containers/vector.h>
 #include <GenAIFramework/Communication/AIModelAgentBus.h>
@@ -16,25 +16,25 @@
 
 namespace GenAIFramework
 {
-    ChatFeature::ChatFeature(AZ::u64 agentId, AZ::u64 conversationId)
+    O3DEAssistantFeature::O3DEAssistantFeature(AZ::u64 agentId, AZ::u64 conversationId)
         : FeatureBase(agentId, conversationId)
     {
     }
 
-    void ChatFeature::Reflect(AZ::ReflectContext* context)
+    void O3DEAssistantFeature::Reflect(AZ::ReflectContext* context)
     {
         if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<ChatFeature, FeatureBase>()->Version(0);
+            serializeContext->Class<O3DEAssistantFeature, FeatureBase>()->Version(0);
         }
 
         if (auto registrationContext = azrtti_cast<GenAIFramework::SystemRegistrationContext*>(context))
         {
-            registrationContext->RegisterFeature<ChatFeature>("Chat");
+            registrationContext->RegisterFeature<O3DEAssistantFeature>("O3DE Assistant");
         }
     }
 
-    void ChatFeature::OnNewMessage(const AZStd::string& message)
+    void O3DEAssistantFeature::OnNewMessage(const AZStd::string& message)
     {
         AIHistory history;
         AIModelAgentBus::EventResult(history, m_agentId, &AIModelAgentBus::Events::GetHistory);
@@ -55,7 +55,7 @@ namespace GenAIFramework
         AIModelAgentBus::Event(m_agentId, &AIModelAgentBus::Events::SendPrompt, messages);
     }
 
-    void ChatFeature::OnPromptResponse(ModelAPIExtractedResponse response)
+    void O3DEAssistantFeature::OnPromptResponse(ModelAPIExtractedResponse response)
     {
         if (!response.IsSuccess())
         {

--- a/Gems/GenAIFramework/Code/Source/O3DEAssistantFeature/O3DEAssistantFeature.h
+++ b/Gems/GenAIFramework/Code/Source/O3DEAssistantFeature/O3DEAssistantFeature.h
@@ -14,15 +14,15 @@
 
 namespace GenAIFramework
 {
-    class ChatFeature : public FeatureBase
+    class O3DEAssistantFeature : public FeatureBase
     {
     public:
-        AZ_RTTI(ChatFeature, "{2c753228-4d1c-4632-9182-2f2e39970d9b}", FeatureBase);
-        AZ_CLASS_ALLOCATOR(ChatFeature, AZ::SystemAllocator, 0);
+        AZ_RTTI(O3DEAssistantFeature, "{2c753228-4d1c-4632-9182-2f2e39970d9b}", FeatureBase);
+        AZ_CLASS_ALLOCATOR(O3DEAssistantFeature, AZ::SystemAllocator, 0);
 
-        ChatFeature() = default;
-        ChatFeature(AZ::u64 agentId, AZ::u64 conversationId);
-        ~ChatFeature() = default;
+        O3DEAssistantFeature() = default;
+        O3DEAssistantFeature(AZ::u64 agentId, AZ::u64 conversationId);
+        ~O3DEAssistantFeature() = default;
 
         static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/GenAIFramework/Code/genaiframework_private_files.cmake
+++ b/Gems/GenAIFramework/Code/genaiframework_private_files.cmake
@@ -17,6 +17,6 @@ set(FILES
 
     Source/Feature/FeatureBase.cpp
 
-    Source/ChatFeature/ChatFeature.cpp
-    Source/ChatFeature/ChatFeature.h
+    Source/O3DEAssistantFeature/O3DEAssistantFeature.cpp
+    Source/O3DEAssistantFeature/O3DEAssistantFeature.h
 )


### PR DESCRIPTION
The chat is hard-coded to be an AI assistant for O3DE, so it should be named accordingly.