### PR TITLE
Disable the button when a chat is processed

### DIFF
--- a/Gems/GenAIFramework/Code/Source/UI/ChatWidget.h
+++ b/Gems/GenAIFramework/Code/Source/UI/ChatWidget.h
@@ -61,6 +61,7 @@ namespace GenAIFramework
         AZStd::queue<AZStd::pair<SummaryDetailedPair, bool>> m_chatMessagesQueue;
         AZStd::mutex m_chatMessagesQueueMutex;
 
+        bool m_isMessageBeingProcessed = false;
         AZStd::unordered_map<QPushButton*, AZStd::vector<AZStd::string>> m_chatDetails;
     };
 } // namespace GenAIFramework


### PR DESCRIPTION
I've added a functionality that disables the send button when a message is being processed. I've also added a check for EBus handlers so that it is not possible to disable the button when it cannot be reenabled.

Resolves #122.