### PR TITLE
Code cleaning: clang-format, includes, etc.

### DIFF
--- a/Gems/GenAIAmazonBedrockVendorBundle/Code/Include/GenAIAmazonBedrockVendorBundle/GenAIAmazonBedrockVendorBundleTypeIds.h
+++ b/Gems/GenAIAmazonBedrockVendorBundle/Code/Include/GenAIAmazonBedrockVendorBundle/GenAIAmazonBedrockVendorBundleTypeIds.h
@@ -19,4 +19,8 @@ namespace GenAIAmazonBedrockVendorBundle
 
     // Interface TypeIds
     inline constexpr const char* GenAIAmazonBedrockVendorBundleRequestsTypeId = "{6C8FBE18-3AC9-4436-B2E7-7BA943C26D69}";
+
+    // Providers/Claude TypeIds
+    inline constexpr const char* ClaudeAmazonBedrockProviderConfigurationTypeId = "{769166CB-BD18-4FB0-B9FF-93DBAAAF82A8}";
+    inline constexpr const char* ClaudeAmazonBedrockProviderTypeId = "{77F1B8E1-E616-44C0-A6C6-9D1BD26CF751}";
 } // namespace GenAIAmazonBedrockVendorBundle

--- a/Gems/GenAIAmazonBedrockVendorBundle/Code/Source/GenAIAmazonBedrockVendorBundleModuleInterface.cpp
+++ b/Gems/GenAIAmazonBedrockVendorBundle/Code/Source/GenAIAmazonBedrockVendorBundleModuleInterface.cpp
@@ -7,8 +7,6 @@
  */
 
 #include "GenAIAmazonBedrockVendorBundleModuleInterface.h"
-
-#include <AzCore/Memory/Memory.h>
 #include <GenAIAmazonBedrockVendorBundle/GenAIAmazonBedrockVendorBundleTypeIds.h>
 #include <Providers/Claude/ClaudeAmazonBedrockProvider.h>
 
@@ -27,11 +25,7 @@ namespace GenAIAmazonBedrockVendorBundle
         // Add ALL components descriptors associated with this gem to m_descriptors.
         // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
         // This happens through the [MyComponent]::Reflect() function.
-        m_descriptors.insert(
-            m_descriptors.end(),
-            {
-                ClaudeAmazonBedrockProvider::CreateDescriptor(),
-            });
+        m_descriptors.insert(m_descriptors.end(), { ClaudeAmazonBedrockProvider::CreateDescriptor() });
     }
 
     AZ::ComponentTypeList GenAIAmazonBedrockVendorBundleModuleInterface::GetRequiredSystemComponents() const

--- a/Gems/GenAIAmazonBedrockVendorBundle/Code/Source/Providers/Claude/ClaudeAmazonBedrockProvider.cpp
+++ b/Gems/GenAIAmazonBedrockVendorBundle/Code/Source/Providers/Claude/ClaudeAmazonBedrockProvider.cpp
@@ -7,16 +7,14 @@
  */
 
 #include "ClaudeAmazonBedrockProvider.h"
-#include <AzCore/Component/Component.h>
+#include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
+
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/std/string/string.h>
-#include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
-
 #include <Credential/AWSCredentialBus.h>
-#include <aws/bedrock-runtime/BedrockRuntimeErrors.h>
+
 #include <aws/bedrock-runtime/BedrockRuntimeServiceClientModel.h>
 #include <aws/bedrock-runtime/model/InvokeModelRequest.h>
 #include <aws/bedrock-runtime/model/InvokeModelResult.h>

--- a/Gems/GenAIAmazonBedrockVendorBundle/Code/Source/Providers/Claude/ClaudeAmazonBedrockProvider.h
+++ b/Gems/GenAIAmazonBedrockVendorBundle/Code/Source/Providers/Claude/ClaudeAmazonBedrockProvider.h
@@ -7,11 +7,13 @@
  */
 
 #pragma once
+#include <GenAIAmazonBedrockVendorBundle/GenAIAmazonBedrockVendorBundleTypeIds.h>
+#include <GenAIFramework/Communication/AIServiceProviderBus.h>
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/std/string/string.h>
-#include <GenAIFramework/Communication/AIServiceProviderBus.h>
+
 #include <aws/bedrock-runtime/BedrockRuntimeClient.h>
 #include <aws/bedrock-runtime/BedrockRuntimeErrors.h>
 #include <aws/bedrock-runtime/BedrockRuntimeServiceClientModel.h>
@@ -23,7 +25,7 @@ namespace GenAIAmazonBedrockVendorBundle
     class ClaudeAmazonBedrockProviderConfiguration : public AZ::ComponentConfig
     {
     public:
-        AZ_RTTI(ClaudeAmazonBedrockProviderConfiguration, "{769166cb-bd18-4fb0-b9ff-93dbaaaf82a8}");
+        AZ_RTTI(ClaudeAmazonBedrockProviderConfiguration, ClaudeAmazonBedrockProviderConfigurationTypeId);
         AZ_CLASS_ALLOCATOR(ClaudeAmazonBedrockProviderConfiguration, AZ::SystemAllocator);
 
         ClaudeAmazonBedrockProviderConfiguration() = default;
@@ -40,7 +42,7 @@ namespace GenAIAmazonBedrockVendorBundle
         , private GenAIFramework::AIServiceProviderBus::Handler
     {
     public:
-        AZ_COMPONENT(ClaudeAmazonBedrockProvider, "{77f1b8e1-e616-44c0-a6c6-9d1bd26cf751}");
+        AZ_COMPONENT(ClaudeAmazonBedrockProvider, ClaudeAmazonBedrockProviderTypeId);
 
         ClaudeAmazonBedrockProvider() = default;
         explicit ClaudeAmazonBedrockProvider(const ClaudeAmazonBedrockProviderConfiguration& config);

--- a/Gems/GenAIAmazonBedrockVendorBundle/Code/Source/Providers/Claude/ClaudeAmazonBedrockProvider.h
+++ b/Gems/GenAIAmazonBedrockVendorBundle/Code/Source/Providers/Claude/ClaudeAmazonBedrockProvider.h
@@ -7,6 +7,7 @@
  */
 
 #pragma once
+
 #include <GenAIAmazonBedrockVendorBundle/GenAIAmazonBedrockVendorBundleTypeIds.h>
 #include <GenAIFramework/Communication/AIServiceProviderBus.h>
 

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AIModelAgentBus.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AIModelAgentBus.h
@@ -8,17 +8,18 @@
 
 #pragma once
 
+#include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIFramework/GenAIFrameworkTypeIds.h>
+
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/RTTI/RTTI.h>
-#include <AzCore/std/any.h>
-#include <GenAIFramework/Communication/AIModelRequestBus.h>
 
 namespace GenAIFramework
 {
     class AIModelAgentRequests : public AZ::EBusTraits
     {
     public:
-        AZ_RTTI(AIModelAgentRequests, "{e66d5979-457b-4dfd-a749-ae722101649c}");
+        AZ_RTTI(AIModelAgentRequests, AIModelAgentRequestsTypeId);
         virtual ~AIModelAgentRequests() = default;
 
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
@@ -38,7 +39,7 @@ namespace GenAIFramework
     class AIModelAgentNotifications : public AZ::EBusTraits
     {
     public:
-        AZ_RTTI(AIModelAgentNotifications, "{c317848a-4d75-4e3d-a3a0-e86e621db350}");
+        AZ_RTTI(AIModelAgentNotifications, AIModelAgentNotificationsTypeId);
         virtual ~AIModelAgentNotifications() = default;
 
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
@@ -53,6 +54,6 @@ namespace GenAIFramework
         };
     };
 
-    using AIModelAgentBus = AZ::EBus<AIModelAgentRequests>;
+    using AIModelAgentRequestBus = AZ::EBus<AIModelAgentRequests>;
     using AIModelAgentNotificationBus = AZ::EBus<AIModelAgentNotifications>;
 } // namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AIModelRequestBus.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AIModelRequestBus.h
@@ -39,7 +39,7 @@ namespace GenAIFramework
     class AIModelRequests : public AZ::ComponentBus
     {
     public:
-        AZ_RTTI(AIModelRequests, AIModelRequestTypeId, AZ::ComponentBus);
+        AZ_RTTI(AIModelRequests, AIModelRequestsTypeId, AZ::ComponentBus);
 
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AIModelRequestBus.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AIModelRequestBus.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <GenAIFramework/GenAIFrameworkTypeIds.h>
+
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Name/Name.h>
@@ -34,10 +36,10 @@ namespace GenAIFramework
     using ModelAPIExtractedResponse = AZ::Outcome<AIMessage, AZStd::string>; //!< The type of extracted response from the model
     using AIHistory = AIMessages; //!< The type of AI history
 
-    class AIModelRequest : public AZ::ComponentBus
+    class AIModelRequests : public AZ::ComponentBus
     {
     public:
-        AZ_RTTI(AIModelRequest, "{8c140e10-e3a2-478b-9886-c7c24eb16816}", AZ::ComponentBus);
+        AZ_RTTI(AIModelRequests, AIModelRequestTypeId, AZ::ComponentBus);
 
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
@@ -80,5 +82,5 @@ namespace GenAIFramework
             return AZ::Failure("This model does not have any parameters to set.");
         }
     };
-    using AIModelRequestBus = AZ::EBus<AIModelRequest>;
+    using AIModelRequestBus = AZ::EBus<AIModelRequests>;
 } // namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AIServiceProviderBus.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AIServiceProviderBus.h
@@ -8,19 +8,21 @@
 
 #pragma once
 
+#include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIFramework/GenAIFrameworkTypeIds.h>
+
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/RTTI/TemplateInfo.h>
-#include <GenAIFramework/Communication/AIModelRequestBus.h>
 
 namespace GenAIFramework
 {
     class AIServiceProviderRequests : public AZ::ComponentBus
     {
     public:
-        AZ_RTTI(AIServiceProviderRequests, "{0bcac4e2-09a9-4702-98dd-ef37006664a7}", AZ::ComponentBus);
+        AZ_RTTI(AIServiceProviderRequests, AIServiceProviderRequestsTypeId, AZ::ComponentBus);
 
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AsyncRequestBus.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/Communication/AsyncRequestBus.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <GenAIFramework/GenAIFrameworkTypeIds.h>
+
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Interface/Interface.h>
@@ -21,7 +23,7 @@ namespace GenAIFramework
     class AsyncRequests
     {
     public:
-        AZ_RTTI(AsyncRequests, "{018e7a12-5db2-7daa-a764-78d7703c8efa}");
+        AZ_RTTI(AsyncRequests, AsyncRequestsTypeId);
 
         //! Set the selected model configuration and service provider with entity ids.
         //! @param modelConfigurationId Entity id of the target model configuration.

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/Feature/ConversationBus.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/Feature/ConversationBus.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <GenAIFramework/GenAIFrameworkTypeIds.h>
+
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/string/string.h>
@@ -17,7 +19,7 @@ namespace GenAIFramework
     class ConversationNotifications : public AZ::EBusTraits
     {
     public:
-        AZ_RTTI(ConversationNotifications, "{b7b4645a-30f4-4bbf-92a6-1328c671b15f}");
+        AZ_RTTI(ConversationNotifications, ConversationNotificationsTypeId);
 
         ConversationNotifications() = default;
         virtual ~ConversationNotifications() = default;

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/Feature/FeatureBase.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/Feature/FeatureBase.h
@@ -8,10 +8,12 @@
 
 #pragma once
 
-#include <AzCore/RTTI/RTTI.h>
-#include <AzCore/Serialization/SerializeContext.h>
 #include <GenAIFramework/Communication/AIModelAgentBus.h>
 #include <GenAIFramework/Feature/ConversationBus.h>
+#include <GenAIFramework/GenAIFrameworkTypeIds.h>
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace GenAIFramework
 {
@@ -20,7 +22,7 @@ namespace GenAIFramework
         , public AIModelAgentNotificationBus::Handler
     {
     public:
-        AZ_RTTI(FeatureBase, "{4050040a-31c3-4949-8ce0-52fad7562f4d}");
+        AZ_RTTI(FeatureBase, FeatureBaseTypeId);
 
         FeatureBase() = default;
         FeatureBase(AZ::u64 agentId, AZ::u64 conversationId)

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/GenAIFrameworkBus.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/GenAIFrameworkBus.h
@@ -27,7 +27,6 @@ namespace GenAIFramework
         AZ_RTTI(GenAIFrameworkRequests, GenAIFrameworkRequestsTypeId);
         virtual ~GenAIFrameworkRequests() = default;
 
-
         //! Get a system registration context.
         //! @return A pointer to the SystemRegistrationContext object.
         virtual SystemRegistrationContext* GetSystemRegistrationContext() const = 0;

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/GenAIFrameworkEditorBus.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/GenAIFrameworkEditorBus.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <GenAIFramework/GenAIFrameworkTypeIds.h>
+
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/EBus/EBus.h>
@@ -20,7 +21,7 @@ namespace GenAIFramework
     class GenAIFrameworkEditorRequests
     {
     public:
-        AZ_RTTI(GenAIFrameworkEditorRequests, "{b20ba166-2237-4f0c-afcd-fb17b63a9cf6}");
+        AZ_RTTI(GenAIFrameworkEditorRequests, GenAIFrameworkEditorRequestsTypeId);
         virtual ~GenAIFrameworkEditorRequests() = default;
 
         virtual void SaveSystemConfiguration() = 0;

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/GenAIFrameworkTypeIds.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/GenAIFrameworkTypeIds.h
@@ -22,7 +22,7 @@ namespace GenAIFramework
     inline constexpr const char* SystemRegistrationContextTypeId = "{E162937C-0177-4CED-87B3-3B037A44C394}";
     inline constexpr const char* AsyncRequestsTypeId = "{018E7A12-5DB2-7DAA-A764-78D7703C8EFA}";
     inline constexpr const char* AIServiceProviderRequestsTypeId = "{0BCAC4E2-09A9-4702-98DD-EF37006664A7}";
-    inline constexpr const char* AIModelRequestTypeId = "{8C140E10-E3A2-478B-9886-C7C24EB16816}";
+    inline constexpr const char* AIModelRequestsTypeId = "{8C140E10-E3A2-478B-9886-C7C24EB16816}";
     inline constexpr const char* AIModelAgentRequestsTypeId = "{E66D5979-457B-4DFD-A749-AE722101649C}";
     inline constexpr const char* AIModelAgentNotificationsTypeId = "{C317848A-4D75-4E3D-A3A0-E86E621DB350}";
     inline constexpr const char* ConversationNotificationsTypeId = "{B7B4645A-30F4-4BBF-92A6-1328C671B15F}";

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/GenAIFrameworkTypeIds.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/GenAIFrameworkTypeIds.h
@@ -1,10 +1,10 @@
 /*
-* Copyright (c) Contributors to the Open 3D Engine Project.
-* For complete copyright and license terms please see the LICENSE at the root of this distribution.
-*
-* SPDX-License-Identifier: Apache-2.0 OR MIT
-*
-*/
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
 
 #pragma once
 
@@ -13,9 +13,19 @@ namespace GenAIFramework
     // System Component TypeIds
     inline constexpr const char* GenAIFrameworkSystemComponentTypeId = "{C1447E9E-C102-4FDA-8D62-34BEE2DD4D31}";
     inline constexpr const char* GenAIFrameworkEditorSystemComponentTypeId = "{CD496C8B-7D2A-447B-A1F9-B449A9BFEC04}";
+    inline constexpr const char* GenAIFrameworkSystemComponentConfigurationTypeId = "{6AB6E636-60DC-4377-BD45-2326CF6A0069}";
 
     inline constexpr const char* GenAIAsyncRequestSystemComponentTypeId = "{D2D195A2-C720-4961-9AEF-C00FCB0AA70D}";
-    inline constexpr const char* GenAIAsyncRequestEditorSystemComponentTypeId = "{018e7a45-43ae-7e69-8bd9-0751b9170bf5}";
+    inline constexpr const char* GenAIAsyncRequestEditorSystemComponentTypeId = "{018E7A45-43AE-7E69-8BD9-0751B9170BF5}";
+
+    // Communication TypeIds
+    inline constexpr const char* SystemRegistrationContextTypeId = "{E162937C-0177-4CED-87B3-3B037A44C394}";
+    inline constexpr const char* AsyncRequestsTypeId = "{018E7A12-5DB2-7DAA-A764-78D7703C8EFA}";
+    inline constexpr const char* AIServiceProviderRequestsTypeId = "{0BCAC4E2-09A9-4702-98DD-EF37006664A7}";
+    inline constexpr const char* AIModelRequestTypeId = "{8C140E10-E3A2-478B-9886-C7C24EB16816}";
+    inline constexpr const char* AIModelAgentRequestsTypeId = "{E66D5979-457B-4DFD-A749-AE722101649C}";
+    inline constexpr const char* AIModelAgentNotificationsTypeId = "{C317848A-4D75-4E3D-A3A0-E86E621DB350}";
+    inline constexpr const char* ConversationNotificationsTypeId = "{B7B4645A-30F4-4BBF-92A6-1328C671B15F}";
 
     // Module derived classes TypeIds
     inline constexpr const char* GenAIFrameworkModuleInterfaceTypeId = "{4ACED336-C28C-4163-996C-4645A0EF6510}";
@@ -27,4 +37,9 @@ namespace GenAIFramework
     // Interface TypeIds
     inline constexpr const char* GenAIFrameworkRequestsTypeId = "{3C39C889-9AA7-43F9-820A-DAF53095BAAD}";
     inline constexpr const char* GenAIFrameworkActionRequestsTypeId = "{D2D195A2-C720-4961-9AEF-C00FCB0AA70D}";
+    inline constexpr const char* GenAIFrameworkEditorRequestsTypeId = "{B20BA166-2237-4F0C-AFCD-FB17B63A9CF6}";
+    inline constexpr const char* FeatureBaseTypeId = "{4050040A-31C3-4949-8CE0-52FAD7562F4D}";
+
+    // Feature TypeIds
+    inline constexpr const char* O3DEAssistantFeatureTypeId = "{2C753228-4D1C-4632-9182-2F2E39970D9B}";
 } // namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Include/GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h
+++ b/Gems/GenAIFramework/Code/Include/GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h
@@ -8,14 +8,16 @@
 
 #pragma once
 
+#include <GenAIFramework/Feature/FeatureBase.h>
+#include <GenAIFramework/GenAIFrameworkTypeIds.h>
+
 #include <AzCore/Math/Uuid.h>
 #include <AzCore/Memory/Memory_fwd.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
-#include <AzCore/std/smart_ptr/shared_ptr.h>
-#include <GenAIFramework/Feature/FeatureBase.h>
 
 namespace GenAIFramework
 {
@@ -26,7 +28,7 @@ namespace GenAIFramework
         ~SystemRegistrationContext() = default;
 
         AZ_CLASS_ALLOCATOR(SystemRegistrationContext, AZ::SystemAllocator);
-        AZ_RTTI(SystemRegistrationContext, "{e162937c-0177-4ced-87b3-3b037a44c394}", AZ::ReflectContext);
+        AZ_RTTI(SystemRegistrationContext, SystemRegistrationContextTypeId, AZ::ReflectContext);
 
         template<class C>
         void RegisterServiceProvider()

--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIAsyncRequestSystemComponent.cpp
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIAsyncRequestSystemComponent.cpp
@@ -7,13 +7,14 @@
  */
 
 #include "GenAIAsyncRequestSystemComponent.h"
+#include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIFramework/Communication/AIServiceProviderBus.h>
+#include <GenAIFramework/GenAIFrameworkBus.h>
+
 #include <AzCore/Component/Entity.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <GenAIFramework/Communication/AIModelRequestBus.h>
-#include <GenAIFramework/Communication/AIServiceProviderBus.h>
-#include <GenAIFramework/GenAIFrameworkBus.h>
 
 namespace GenAIFramework
 {
@@ -340,8 +341,7 @@ namespace GenAIFramework
 
     AZStd::string GenAIAsyncRequestSystemComponent::GetServiceProviderTypename()
     {
-        return GetComponentTypename(
-            GenAIFrameworkInterface::Get()->GetServiceProviderNamesAndComponentTypeIds(), m_serviceProviderId);
+        return GetComponentTypename(GenAIFrameworkInterface::Get()->GetServiceProviderNamesAndComponentTypeIds(), m_serviceProviderId);
     }
 
 } // namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIAsyncRequestSystemComponent.h
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIAsyncRequestSystemComponent.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <GenAIFramework/Communication/AsyncRequestBus.h>
+
 #include "AzCore/Component/EntityId.h"
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/Entity.h>
@@ -15,7 +17,6 @@
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/string/string.h>
-#include <GenAIFramework/Communication/AsyncRequestBus.h>
 
 namespace GenAIFramework
 {

--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIAsyncRequestSystemComponent.h
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIAsyncRequestSystemComponent.h
@@ -10,9 +10,9 @@
 
 #include <GenAIFramework/Communication/AsyncRequestBus.h>
 
-#include "AzCore/Component/EntityId.h"
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/Entity.h>
+#include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Uuid.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/parallel/mutex.h>

--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponent.cpp
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponent.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "GenAIFrameworkSystemComponent.h"
-
 #include <Clients/GenAIFrameworkSystemComponentConfiguration.h>
 #include <GenAIFramework/Feature/FeatureBase.h>
 #include <GenAIFramework/GenAIFrameworkTypeIds.h>

--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponent.h
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponent.h
@@ -8,16 +8,17 @@
 
 #pragma once
 
-#include <AzCore/Component/Component.h>
-#include <AzCore/Component/Entity.h>
-#include <AzCore/Component/EntityId.h>
-#include <AzCore/base.h>
-#include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <Clients/GenAIFrameworkSystemComponentConfiguration.h>
 #include <GenAIFramework/GenAIFrameworkBus.h>
 #include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
 #include <ModelAgent/ModelAgent.h>
 #include <SettingsRegistryManager/SettingsRegistryManager.h>
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/base.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
 
 namespace GenAIFramework
 {

--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponentConfiguration.cpp
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponentConfiguration.cpp
@@ -16,7 +16,7 @@ namespace GenAIFramework
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<GenAIFrameworkSystemComponentConfiguration>()
-                ->Version(1)
+                ->Version(0)
                 ->Field("ServiceProviders", &GenAIFrameworkSystemComponentConfiguration::m_serviceProviders)
                 ->Field("ModelConfigurations", &GenAIFrameworkSystemComponentConfiguration::m_modelConfigurations);
         }

--- a/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponentConfiguration.h
+++ b/Gems/GenAIFramework/Code/Source/Clients/GenAIFrameworkSystemComponentConfiguration.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <GenAIFramework/GenAIFrameworkTypeIds.h>
+
 #include <AzCore/Component/Entity.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/Serialization/SerializeContext.h>
@@ -20,7 +22,7 @@ namespace GenAIFramework
     class GenAIFrameworkSystemComponentConfiguration
     {
     public:
-        AZ_RTTI(GenAIFrameworkSystemComponentConfiguration, "{6ab6e636-60dc-4377-bd45-2326cf6a0069}");
+        AZ_RTTI(GenAIFrameworkSystemComponentConfiguration, GenAIFrameworkSystemComponentConfigurationTypeId);
         AZ_CLASS_ALLOCATOR(GenAIFrameworkSystemComponentConfiguration, AZ::SystemAllocator);
 
         static void Reflect(AZ::ReflectContext* context);

--- a/Gems/GenAIFramework/Code/Source/GenAIFrameworkModuleInterface.cpp
+++ b/Gems/GenAIFramework/Code/Source/GenAIFrameworkModuleInterface.cpp
@@ -7,12 +7,13 @@
  */
 
 #include "GenAIFrameworkModuleInterface.h"
-#include <AzCore/Component/ComponentApplication.h>
-#include <AzCore/Memory/Memory.h>
 #include <Clients/GenAIAsyncRequestSystemComponent.h>
 #include <Clients/GenAIFrameworkSystemComponent.h>
 #include <GenAIFramework/GenAIFrameworkTypeIds.h>
 #include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
+
+#include <AzCore/Component/ComponentApplication.h>
+#include <AzCore/Memory/Memory.h>
 
 namespace GenAIFramework
 {
@@ -28,10 +29,7 @@ namespace GenAIFramework
         // This happens through the [MyComponent]::Reflect() function.
         m_descriptors.insert(
             m_descriptors.end(),
-            {
-                GenAIFrameworkSystemComponent::CreateDescriptor(),
-                GenAIAsyncRequestSystemComponent::CreateDescriptor(),
-            });
+            { GenAIFrameworkSystemComponent::CreateDescriptor(), GenAIAsyncRequestSystemComponent::CreateDescriptor() });
 
         // Create a new reflection context for reflecting serviceProviders and modelConfigurations
         AZ::ReflectionEnvironment::GetReflectionManager()->AddReflectContext<SystemRegistrationContext>();

--- a/Gems/GenAIFramework/Code/Source/GenAIFrameworkModuleInterface.h
+++ b/Gems/GenAIFramework/Code/Source/GenAIFrameworkModuleInterface.h
@@ -1,10 +1,10 @@
 /*
-* Copyright (c) Contributors to the Open 3D Engine Project.
-* For complete copyright and license terms please see the LICENSE at the root of this distribution.
-*
-* SPDX-License-Identifier: Apache-2.0 OR MIT
-*
-*/
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
 
 #include <AzCore/Memory/Memory_fwd.h>
 #include <AzCore/Module/Module.h>
@@ -13,8 +13,7 @@
 
 namespace GenAIFramework
 {
-    class GenAIFrameworkModuleInterface
-        : public AZ::Module
+    class GenAIFrameworkModuleInterface : public AZ::Module
     {
     public:
         AZ_TYPE_INFO_WITH_NAME_DECL(GenAIFrameworkModuleInterface)
@@ -28,4 +27,4 @@ namespace GenAIFramework
          */
         AZ::ComponentTypeList GetRequiredSystemComponents() const override;
     };
-}// namespace GenAIFramework
+} // namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Source/ModelAgent/ModelAgent.cpp
+++ b/Gems/GenAIFramework/Code/Source/ModelAgent/ModelAgent.cpp
@@ -17,12 +17,12 @@ namespace GenAIFramework
         , m_modelConfigurationId(modelConfigurationId)
         , m_agentId(agentId)
     {
-        AIModelAgentBus::Handler::BusConnect(m_agentId);
+        AIModelAgentRequestBus::Handler::BusConnect(m_agentId);
     }
 
     ModelAgent::~ModelAgent()
     {
-        AIModelAgentBus::Handler::BusDisconnect(m_agentId);
+        AIModelAgentRequestBus::Handler::BusDisconnect(m_agentId);
     }
 
     void ModelAgent::SendPrompt(const AIMessages& prompt)

--- a/Gems/GenAIFramework/Code/Source/ModelAgent/ModelAgent.h
+++ b/Gems/GenAIFramework/Code/Source/ModelAgent/ModelAgent.h
@@ -8,23 +8,23 @@
 
 #pragma once
 
+#include <GenAIFramework/Communication/AIModelAgentBus.h>
+
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/std/any.h>
 #include <AzCore/std/containers/vector.h>
-#include <GenAIFramework/Communication/AIModelAgentBus.h>
 
 namespace GenAIFramework
 {
-
-    class ModelAgent : public AIModelAgentBus::Handler
+    class ModelAgent : public AIModelAgentRequestBus::Handler
     {
     public:
         ModelAgent() = delete; // Do not allow to construct the agent without ids
         ModelAgent(const AZ::EntityId& serviceProviderId, const AZ::EntityId& modelConfigurationId, AZ::u64 agentId);
         ~ModelAgent();
 
-        // AIModelAgentBus::Handler
+        // AIModelAgentRequestBus::Handler
         void SendPrompt(const AIMessages& prompt) override;
         AIHistory GetHistory() const override;
 

--- a/Gems/GenAIFramework/Code/Source/O3DEAssistantFeature/O3DEAssistantFeature.cpp
+++ b/Gems/GenAIFramework/Code/Source/O3DEAssistantFeature/O3DEAssistantFeature.cpp
@@ -7,12 +7,12 @@
  */
 
 #include "O3DEAssistantFeature.h"
-
-#include <AzCore/std/containers/vector.h>
 #include <GenAIFramework/Communication/AIModelAgentBus.h>
 #include <GenAIFramework/Communication/AIModelRequestBus.h>
 #include <GenAIFramework/Feature/ConversationBus.h>
 #include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
+
+#include <AzCore/std/containers/vector.h>
 
 namespace GenAIFramework
 {
@@ -37,7 +37,7 @@ namespace GenAIFramework
     void O3DEAssistantFeature::OnNewMessage(const AZStd::string& message)
     {
         AIHistory history;
-        AIModelAgentBus::EventResult(history, m_agentId, &AIModelAgentBus::Events::GetHistory);
+        AIModelAgentRequestBus::EventResult(history, m_agentId, &AIModelAgentRequestBus::Events::GetHistory);
 
         AIMessages messages = history;
         AIMessage newMessage = { Role::User, { AZStd::any(message) } };
@@ -52,7 +52,7 @@ namespace GenAIFramework
         };
         messages.push_back(systemMessage);
 
-        AIModelAgentBus::Event(m_agentId, &AIModelAgentBus::Events::SendPrompt, messages);
+        AIModelAgentRequestBus::Event(m_agentId, &AIModelAgentRequestBus::Events::SendPrompt, messages);
     }
 
     void O3DEAssistantFeature::OnPromptResponse(ModelAPIExtractedResponse response)

--- a/Gems/GenAIFramework/Code/Source/O3DEAssistantFeature/O3DEAssistantFeature.h
+++ b/Gems/GenAIFramework/Code/Source/O3DEAssistantFeature/O3DEAssistantFeature.h
@@ -8,16 +8,18 @@
 
 #pragma once
 
+#include <GenAIFramework/Feature/FeatureBase.h>
+#include <GenAIFramework/GenAIFrameworkTypeIds.h>
+
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <GenAIFramework/Feature/FeatureBase.h>
 
 namespace GenAIFramework
 {
     class O3DEAssistantFeature : public FeatureBase
     {
     public:
-        AZ_RTTI(O3DEAssistantFeature, "{2c753228-4d1c-4632-9182-2f2e39970d9b}", FeatureBase);
+        AZ_RTTI(O3DEAssistantFeature, O3DEAssistantFeatureTypeId, FeatureBase);
         AZ_CLASS_ALLOCATOR(O3DEAssistantFeature, AZ::SystemAllocator, 0);
 
         O3DEAssistantFeature() = default;

--- a/Gems/GenAIFramework/Code/Source/SettingsRegistryManager/Editor/EditorSettingsRegistryManager.cpp
+++ b/Gems/GenAIFramework/Code/Source/SettingsRegistryManager/Editor/EditorSettingsRegistryManager.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "EditorSettingsRegistryManager.h"
+
 #include <AzCore/Outcome/Outcome.h>
 
 namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Source/SettingsRegistryManager/Editor/EditorSettingsRegistryManager.h
+++ b/Gems/GenAIFramework/Code/Source/SettingsRegistryManager/Editor/EditorSettingsRegistryManager.h
@@ -8,13 +8,14 @@
 
 #pragma once
 
+#include <SettingsRegistryManager/SettingsRegistryManager.h>
+
 #include <AzCore/IO/ByteContainerStream.h>
 #include <AzCore/IO/TextStreamWriters.h>
 #include <AzCore/JSON/pointer.h>
 #include <AzCore/JSON/prettywriter.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzToolsFramework/SourceControl/SourceControlAPI.h>
-#include <SettingsRegistryManager/SettingsRegistryManager.h>
 
 namespace GenAIFramework
 {
@@ -36,7 +37,6 @@ namespace GenAIFramework
             return [payloadBuffer = AZStd::move(configurationPayload),
                     postSaveCB = AZStd::move(postSaveCallback)](bool success, const AzToolsFramework::SourceControlFileInfo& info)
             {
-
                 if (info.IsLockedByOther())
                 {
                     AZ_Warning(

--- a/Gems/GenAIFramework/Code/Source/SettingsRegistryManager/SettingsRegistryManager.cpp
+++ b/Gems/GenAIFramework/Code/Source/SettingsRegistryManager/SettingsRegistryManager.cpp
@@ -7,8 +7,8 @@
  */
 
 #include "SettingsRegistryManager.h"
+
 #include <AzCore/Debug/Trace.h>
-#include <AzCore/Outcome/Outcome.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 
 namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Source/SettingsRegistryManager/SettingsRegistryManager.h
+++ b/Gems/GenAIFramework/Code/Source/SettingsRegistryManager/SettingsRegistryManager.h
@@ -8,11 +8,10 @@
 
 #pragma once
 
-#include "AzCore/std/string/string_view.h"
 #include "Clients/GenAIFrameworkSystemComponentConfiguration.h"
-#include <AzCore/Component/Entity.h>
-#include <AzCore/std/containers/map.h>
+
 #include <AzCore/std/optional.h>
+#include <AzCore/std/string/string_view.h>
 
 namespace GenAIFramework
 {

--- a/Gems/GenAIFramework/Code/Source/Tools/GenAIAsyncRequestEditorSystemComponent.cpp
+++ b/Gems/GenAIFramework/Code/Source/Tools/GenAIAsyncRequestEditorSystemComponent.cpp
@@ -7,15 +7,12 @@
  */
 
 #include "GenAIAsyncRequestEditorSystemComponent.h"
-#include "SettingsRegistryManager/SettingsRegistryManager.h"
-
-#include <API/ViewPaneOptions.h>
-#include <AzCore/Component/Entity.h>
-#include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/std/containers/vector.h>
-#include <AzCore/std/smart_ptr/make_shared.h>
 #include <GenAIFramework/GenAIFrameworkEditorBus.h>
 #include <GenAIFramework/GenAIFrameworkTypeIds.h>
+#include <SettingsRegistryManager/SettingsRegistryManager.h>
+
+#include <AzCore/Component/Entity.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace GenAIFramework
 {

--- a/Gems/GenAIFramework/Code/Source/Tools/GenAIAsyncRequestEditorSystemComponent.h
+++ b/Gems/GenAIFramework/Code/Source/Tools/GenAIAsyncRequestEditorSystemComponent.h
@@ -8,7 +8,8 @@
 
 #pragma once
 
-#include "Clients/GenAIAsyncRequestSystemComponent.h"
+#include <Clients/GenAIAsyncRequestSystemComponent.h>
+
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 

--- a/Gems/GenAIFramework/Code/Source/Tools/GenAIFrameworkEditorModule.cpp
+++ b/Gems/GenAIFramework/Code/Source/Tools/GenAIFrameworkEditorModule.cpp
@@ -10,7 +10,6 @@
 #include "GenAIFrameworkEditorSystemComponent.h"
 #include <GenAIFramework/GenAIFrameworkTypeIds.h>
 #include <GenAIFrameworkModuleInterface.h>
-#include <QtCore/qglobal.h>
 
 void InitQtResources()
 {

--- a/Gems/GenAIFramework/Code/Source/Tools/GenAIFrameworkEditorSystemComponent.cpp
+++ b/Gems/GenAIFramework/Code/Source/Tools/GenAIFrameworkEditorSystemComponent.cpp
@@ -14,7 +14,6 @@
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/containers/vector.h>
-#include <AzCore/std/smart_ptr/make_shared.h>
 #include <GenAIFramework/GenAIFrameworkBus.h>
 #include <GenAIFramework/GenAIFrameworkEditorBus.h>
 #include <GenAIFramework/GenAIFrameworkTypeIds.h>

--- a/Gems/GenAIFramework/Code/Source/Tools/GenAIFrameworkEditorSystemComponent.h
+++ b/Gems/GenAIFramework/Code/Source/Tools/GenAIFrameworkEditorSystemComponent.h
@@ -8,14 +8,13 @@
 
 #pragma once
 
-#include "SettingsRegistryManager/Editor/EditorSettingsRegistryManager.h"
-#include <AzCore/Math/Uuid.h>
-#include <AzCore/std/string/string_view.h>
-#include <AzToolsFramework/API/ToolsApplicationAPI.h>
-#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <Clients/GenAIFrameworkSystemComponent.h>
 #include <GenAIFramework/GenAIFrameworkBus.h>
 #include <GenAIFramework/GenAIFrameworkEditorBus.h>
+#include <SettingsRegistryManager/Editor/EditorSettingsRegistryManager.h>
+
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 
 namespace GenAIFramework
 {

--- a/Gems/GenAIFramework/Code/Source/UI/AIAssistantWidget.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/AIAssistantWidget.cpp
@@ -8,21 +8,23 @@
  */
 
 #include "AIAssistantWidget.h"
-#include "ChatWidget.h"
-#include "NewChatWidget.h"
+#include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIFramework/Communication/AIServiceProviderBus.h>
+#include <GenAIFramework/Communication/AsyncRequestBus.h>
+#include <GenAIFramework/GenAIFrameworkBus.h>
+#include <UI/ChatWidget.h>
+#include <UI/NewChatWidget.h>
+
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/containers/vector.h>
 
-#include <AzCore/Component/ComponentApplicationBus.h>
-#include <GenAIFramework/Communication/AIModelRequestBus.h>
-#include <GenAIFramework/Communication/AIServiceProviderBus.h>
-#include <GenAIFramework/Communication/AsyncRequestBus.h>
-#include <GenAIFramework/GenAIFrameworkBus.h>
 #include <QMessageBox>
 #include <QScrollBar>
 #include <QSettings>
+
 #include <Source/UI/ui_AIAssistantWidget.h>
 
 namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Source/UI/AIAssistantWidget.h
+++ b/Gems/GenAIFramework/Code/Source/UI/AIAssistantWidget.h
@@ -9,17 +9,17 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
+#include <GenAIFramework/GenAIFrameworkBus.h>
+#include <UI/AgentConfigurationWidget/AgentConfigurationWidget.h>
+#include <UI/NewChatWidget.h>
+
 #include <AzCore/Component/Entity.h>
 #include <AzCore/std/containers/unordered_map.h>
-#include <GenAIFramework/GenAIFrameworkBus.h>
+
 #include <QLabel>
 #include <QMainWindow>
 #include <QMap>
 #include <QWidget>
-
-#include <UI/AgentConfigurationWidget/AgentConfigurationWidget.h>
-#include <UI/NewChatWidget.h>
-
 #endif
 
 namespace Ui

--- a/Gems/GenAIFramework/Code/Source/UI/AgentConfigurationWidget/Segment.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/AgentConfigurationWidget/Segment.cpp
@@ -28,7 +28,7 @@ namespace GenAIFramework
         AZ::ComponentApplicationBus::BroadcastResult(m_serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
         AZ_Assert(m_serializeContext, "Failed to retrieve serialize context.");
 
-	const AZStd::string name = component->GetNamedEntityId().GetName();
+        const AZStd::string name = component->GetNamedEntityId().GetName();
         m_componentName = new QLabel(name.c_str());
 
         const int propertyLabelWidth = 250;

--- a/Gems/GenAIFramework/Code/Source/UI/ChatWidget.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/ChatWidget.cpp
@@ -8,6 +8,12 @@
  */
 
 #include "ChatWidget.h"
+#include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIFramework/Communication/AIServiceProviderBus.h>
+#include <GenAIFramework/Communication/AsyncRequestBus.h>
+#include <GenAIFramework/Feature/ConversationBus.h>
+#include <GenAIFramework/GenAIFrameworkBus.h>
+#include <UI/DetailsWidget.h>
 
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
@@ -16,18 +22,14 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/parallel/lock.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
-#include <GenAIFramework/Communication/AIModelRequestBus.h>
-#include <GenAIFramework/Communication/AIServiceProviderBus.h>
-#include <GenAIFramework/Communication/AsyncRequestBus.h>
-#include <GenAIFramework/Feature/ConversationBus.h>
-#include <GenAIFramework/GenAIFrameworkBus.h>
+
 #include <QMessageBox>
 #include <QPushButton>
 #include <QScrollBar>
 #include <QSettings>
 #include <QStyle>
+
 #include <Source/UI/ui_ChatWidget.h>
-#include <UI/DetailsWidget.h>
 
 namespace GenAIFramework
 {

--- a/Gems/GenAIFramework/Code/Source/UI/ChatWidget.h
+++ b/Gems/GenAIFramework/Code/Source/UI/ChatWidget.h
@@ -9,14 +9,15 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
-#include <QPushButton>
-#include <QVBoxLayout>
-#include <QWidget>
+#include <GenAIFramework/GenAIFrameworkBus.h>
 
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/std/parallel/mutex.h>
-#include <GenAIFramework/GenAIFrameworkBus.h>
+
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QWidget>
 #endif
 
 namespace Ui

--- a/Gems/GenAIFramework/Code/Source/UI/NewChatWidget.cpp
+++ b/Gems/GenAIFramework/Code/Source/UI/NewChatWidget.cpp
@@ -1,18 +1,20 @@
 #include "NewChatWidget.h"
+#include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIFramework/Communication/AIServiceProviderBus.h>
+#include <GenAIFramework/Communication/AsyncRequestBus.h>
+#include <GenAIFramework/GenAIFrameworkBus.h>
+
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/containers/vector.h>
 
-#include <AzCore/Component/ComponentApplicationBus.h>
-#include <GenAIFramework/Communication/AIModelRequestBus.h>
-#include <GenAIFramework/Communication/AIServiceProviderBus.h>
-#include <GenAIFramework/Communication/AsyncRequestBus.h>
-#include <GenAIFramework/GenAIFrameworkBus.h>
 #include <QMessageBox>
 #include <QScrollBar>
 #include <QSettings>
 #include <QStyle>
+
 #include <Source/UI/ui_NewChatWidget.h>
 
 namespace GenAIFramework

--- a/Gems/GenAIFramework/Code/Source/UI/NewChatWidget.h
+++ b/Gems/GenAIFramework/Code/Source/UI/NewChatWidget.h
@@ -9,14 +9,15 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
+#include <GenAIFramework/GenAIFrameworkBus.h>
+#include <UI/AgentConfigurationWidget/AgentConfigurationWidget.h>
+
+#include <AzCore/Component/Entity.h>
+
 #include <QLabel>
 #include <QMap>
 #include <QVBoxLayout>
 #include <QWidget>
-
-#include <AzCore/Component/Entity.h>
-#include <GenAIFramework/GenAIFrameworkBus.h>
-#include <UI/AgentConfigurationWidget/AgentConfigurationWidget.h>
 
 #endif
 

--- a/Gems/GenAIMock/Code/Include/GenAIMock/GenAIMockBus.h
+++ b/Gems/GenAIMock/Code/Include/GenAIMock/GenAIMockBus.h
@@ -20,7 +20,6 @@ namespace GenAIMock
     public:
         AZ_RTTI(GenAIMockRequests, GenAIMockRequestsTypeId);
         virtual ~GenAIMockRequests() = default;
-        // Put your public methods here
     };
 
     class GenAIMockBusTraits : public AZ::EBusTraits

--- a/Gems/GenAIMock/Code/Include/GenAIMock/GenAIMockTypeIds.h
+++ b/Gems/GenAIMock/Code/Include/GenAIMock/GenAIMockTypeIds.h
@@ -23,4 +23,11 @@ namespace GenAIMock
 
     // Interface TypeIds
     inline constexpr const char* GenAIMockRequestsTypeId = "{F51BC484-EC06-4B28-A2EB-745E1B948EE0}";
+
+    // Communication TypeIds
+    inline constexpr const char* MockServiceComponentConfigurationTypeId = "{47AB736F-33F1-453B-9CDB-96FAFFD5D33E}";
+    inline constexpr const char* MockServiceComponentTypeId = "{DB01BE29-EC0B-41E1-BF68-12D70DD6B630}";
+
+    // ModelConfigurations TypeIds
+    inline constexpr const char* PassthroughModelComponentTypeId = "{B873470C-0CA8-49AF-82B6-4DE26C242C7B}";
 } // namespace GenAIMock

--- a/Gems/GenAIMock/Code/Source/Clients/GenAIMockSystemComponent.cpp
+++ b/Gems/GenAIMock/Code/Source/Clients/GenAIMockSystemComponent.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "GenAIMockSystemComponent.h"
-
 #include <GenAIMock/GenAIMockTypeIds.h>
 
 #include <AzCore/Serialization/SerializeContext.h>

--- a/Gems/GenAIMock/Code/Source/Communication/MockServiceComponent.h
+++ b/Gems/GenAIMock/Code/Source/Communication/MockServiceComponent.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <GenAIFramework/Communication/AIServiceProviderBus.h>
+#include <GenAIMock/GenAIMockTypeIds.h>
 
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/Component.h>
-#include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/std/containers/vector.h>
@@ -23,7 +23,7 @@ namespace GenAIMock
     class MockServiceComponentConfiguration : public AZ::ComponentConfig
     {
     public:
-        AZ_RTTI(MockServiceComponentConfiguration, "{47ab736f-33f1-453b-9cdb-96faffd5d33e}");
+        AZ_RTTI(MockServiceComponentConfiguration, MockServiceComponentConfigurationTypeId);
         AZ_CLASS_ALLOCATOR(MockServiceComponentConfiguration, AZ::SystemAllocator);
 
         MockServiceComponentConfiguration() = default;
@@ -41,7 +41,7 @@ namespace GenAIMock
         , public GenAIFramework::AIServiceProviderBus::Handler
     {
     public:
-        AZ_COMPONENT(MockServiceComponent, "{db01be29-ec0b-41e1-bf68-12d70dd6b630}");
+        AZ_COMPONENT(MockServiceComponent, MockServiceComponentTypeId);
 
         MockServiceComponent() = default;
         explicit MockServiceComponent(const MockServiceComponentConfiguration& config);
@@ -65,7 +65,7 @@ namespace GenAIMock
 
     private:
         MockServiceComponentConfiguration m_configuration;
-        AZStd::vector<AZStd::string> m_testData;
+        AZStd::vector<AZStd::string> m_testData; //!< Buffer with loaded mock prompt responses
         int m_lastCompleted{ -1 }; //!< Interator (number) of the last call that was completed (it can be reset)
 
         void ReloadAsset();

--- a/Gems/GenAIMock/Code/Source/GenAIMockModuleInterface.cpp
+++ b/Gems/GenAIMock/Code/Source/GenAIMockModuleInterface.cpp
@@ -7,12 +7,12 @@
  */
 
 #include "GenAIMockModuleInterface.h"
-#include <AzCore/Memory/Memory.h>
-
 #include <Clients/GenAIMockSystemComponent.h>
 #include <Communication/MockServiceComponent.h>
 #include <GenAIMock/GenAIMockTypeIds.h>
 #include <ModelConfigurations/PassthroughModelComponent.h>
+
+#include <AzCore/Memory/Memory.h>
 
 namespace GenAIMock
 {

--- a/Gems/GenAIMock/Code/Source/ModelConfigurations/PassthroughModelComponent.cpp
+++ b/Gems/GenAIMock/Code/Source/ModelConfigurations/PassthroughModelComponent.cpp
@@ -15,6 +15,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/any.h>
 #include <AzCore/std/string/string.h>
+
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>

--- a/Gems/GenAIMock/Code/Source/ModelConfigurations/PassthroughModelComponent.h
+++ b/Gems/GenAIMock/Code/Source/ModelConfigurations/PassthroughModelComponent.h
@@ -8,11 +8,12 @@
 
 #pragma once
 
+#include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIMock/GenAIMockTypeIds.h>
+
 #include <AzCore/Component/Component.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/RTTI/ReflectContext.h>
-
-#include <GenAIFramework/Communication/AIModelRequestBus.h>
 
 namespace GenAIMock
 {
@@ -21,7 +22,7 @@ namespace GenAIMock
         , public GenAIFramework::AIModelRequestBus::Handler
     {
     public:
-        AZ_COMPONENT(PassthroughModelComponent, "{b873470c-0ca8-49af-82b6-4de26c242c7b}");
+        AZ_COMPONENT(PassthroughModelComponent, PassthroughModelComponentTypeId);
 
         static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/GenAIMock/Code/Source/Tools/GenAIMockEditorModule.cpp
+++ b/Gems/GenAIMock/Code/Source/Tools/GenAIMockEditorModule.cpp
@@ -1,12 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
 
+#include "GenAIMockEditorSystemComponent.h"
 #include <GenAIMock/GenAIMockTypeIds.h>
 #include <GenAIMockModuleInterface.h>
-#include "GenAIMockEditorSystemComponent.h"
 
 namespace GenAIMock
 {
-    class GenAIMockEditorModule
-        : public GenAIMockModuleInterface
+    class GenAIMockEditorModule : public GenAIMockModuleInterface
     {
     public:
         AZ_RTTI(GenAIMockEditorModule, GenAIMockEditorModuleTypeId, GenAIMockModuleInterface);
@@ -16,11 +22,9 @@ namespace GenAIMock
         {
             // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
             // Add ALL components descriptors associated with this gem to m_descriptors.
-            // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
-            // This happens through the [MyComponent]::Reflect() function.
-            m_descriptors.insert(m_descriptors.end(), {
-                GenAIMockEditorSystemComponent::CreateDescriptor(),
-            });
+            // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and
+            // EditContext. This happens through the [MyComponent]::Reflect() function.
+            m_descriptors.insert(m_descriptors.end(), { GenAIMockEditorSystemComponent::CreateDescriptor() });
         }
 
         /**
@@ -29,12 +33,12 @@ namespace GenAIMock
          */
         AZ::ComponentTypeList GetRequiredSystemComponents() const override
         {
-            return AZ::ComponentTypeList {
+            return AZ::ComponentTypeList{
                 azrtti_typeid<GenAIMockEditorSystemComponent>(),
             };
         }
     };
-}// namespace GenAIMock
+} // namespace GenAIMock
 
 #if defined(O3DE_GEM_NAME)
 AZ_DECLARE_MODULE_CLASS(AZ_JOIN(Gem_, O3DE_GEM_NAME, _Editor), GenAIMock::GenAIMockEditorModule)

--- a/Gems/GenAIMock/Code/Source/Tools/GenAIMockEditorSystemComponent.cpp
+++ b/Gems/GenAIMock/Code/Source/Tools/GenAIMockEditorSystemComponent.cpp
@@ -1,20 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "GenAIMockEditorSystemComponent.h"
+#include <GenAIMock/GenAIMockTypeIds.h>
 
 #include <AzCore/Serialization/SerializeContext.h>
-#include "GenAIMockEditorSystemComponent.h"
-
-#include <GenAIMock/GenAIMockTypeIds.h>
 
 namespace GenAIMock
 {
-    AZ_COMPONENT_IMPL(GenAIMockEditorSystemComponent, "GenAIMockEditorSystemComponent",
-        GenAIMockEditorSystemComponentTypeId, BaseSystemComponent);
+    AZ_COMPONENT_IMPL(
+        GenAIMockEditorSystemComponent, "GenAIMockEditorSystemComponent", GenAIMockEditorSystemComponentTypeId, BaseSystemComponent);
 
     void GenAIMockEditorSystemComponent::Reflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<GenAIMockEditorSystemComponent, GenAIMockSystemComponent>()
-                ->Version(0);
+            serializeContext->Class<GenAIMockEditorSystemComponent, GenAIMockSystemComponent>()->Version(0);
         }
     }
 

--- a/Gems/GenAIMock/Code/Source/Tools/GenAIMockEditorSystemComponent.h
+++ b/Gems/GenAIMock/Code/Source/Tools/GenAIMockEditorSystemComponent.h
@@ -1,9 +1,16 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
 
 #pragma once
 
-#include <AzToolsFramework/API/ToolsApplicationAPI.h>
-
 #include <Clients/GenAIMockSystemComponent.h>
+
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
 
 namespace GenAIMock
 {
@@ -13,6 +20,7 @@ namespace GenAIMock
         , protected AzToolsFramework::EditorEvents::Bus::Handler
     {
         using BaseSystemComponent = GenAIMockSystemComponent;
+
     public:
         AZ_COMPONENT_DECL(GenAIMockEditorSystemComponent);
 

--- a/Gems/GenAIVendorBundle/Code/Include/GenAIVendorBundle/GenAIVendorBundleTypeIds.h
+++ b/Gems/GenAIVendorBundle/Code/Include/GenAIVendorBundle/GenAIVendorBundleTypeIds.h
@@ -19,4 +19,19 @@ namespace GenAIVendorBundle
 
     // Interface TypeIds
     inline constexpr const char* GenAIVendorBundleRequestsTypeId = "{F1D5E6A3-0D13-46F9-8B9B-92A85A145625}";
+
+    // Models TypeIds
+    inline constexpr const char* ClaudeModelConfigurationTypeId = "{5A478AB3-8AC6-4C23-8768-03C2791D6B11}";
+    inline constexpr const char* ClaudeModelMessagesAPITypeId = "{9FFED8C5-A872-4ADF-BC80-74BA1FE92E95}";
+    inline constexpr const char* ClaudeModelTextCompletionsTypeId = "{0310426D-3035-4240-B9E5-D1556AF98B47}";
+    inline constexpr const char* OllamaChatModelConfigurationTypeId = "{CE2D1912-94EE-4BCD-9015-E118900F4051}";
+    inline constexpr const char* OllamaChatModelTypeId = "{E82C0C54-0658-419A-8170-033EF06AEA96}";
+    inline constexpr const char* OllamaModelConfigurationTypeId = "{C5FA34FF-2BBB-4DF4-9AA2-C27320B57F93}";
+    inline constexpr const char* OllamaModelTypeId = "{3782988D-058F-4943-9862-874EBC90A240}";
+
+    // Providers TypeIds
+    inline constexpr const char* ClaudeHttpProviderConfigurationTypeId = "{4822D5EC-F30A-4402-9FCE-48826B3183BF}";
+    inline constexpr const char* ClaudeHttpProviderTypeId = "{FFA395BC-1D5B-46E3-B557-10FF550CFB34}";
+    inline constexpr const char* OllamaHttpServiceConfigurationTypeId = "{18DDBA8F-1FE5-4DDE-A0F4-90DCCBDA5F33}";
+    inline constexpr const char* OllamaHttpServiceComponentTypeId = "{AAD62D35-C628-4141-B759-0D3764013B29}";
 } // namespace GenAIVendorBundle

--- a/Gems/GenAIVendorBundle/Code/Source/GenAIVendorBundleModuleInterface.cpp
+++ b/Gems/GenAIVendorBundle/Code/Source/GenAIVendorBundleModuleInterface.cpp
@@ -7,8 +7,6 @@
  */
 
 #include "GenAIVendorBundleModuleInterface.h"
-
-#include <AzCore/Memory/Memory.h>
 #include <GenAIVendorBundle/GenAIVendorBundleTypeIds.h>
 #include <Models/Claude/ClaudeModelMessagesAPI.h>
 #include <Models/Claude/ClaudeModelTextCompletions.h>
@@ -17,6 +15,7 @@
 #include <Providers/Claude/ClaudeHttpProvider.h>
 #include <Providers/Ollama/OllamaHttpProvider.h>
 
+#include <AzCore/Memory/Memory.h>
 namespace GenAIVendorBundle
 {
     AZ_TYPE_INFO_WITH_NAME_IMPL(
@@ -32,14 +31,12 @@ namespace GenAIVendorBundle
         // This happens through the [MyComponent]::Reflect() function.
         m_descriptors.insert(
             m_descriptors.end(),
-            {
-                ClaudeModelTextCompletions::CreateDescriptor(),
-                ClaudeModelMessagesAPI::CreateDescriptor(),
-                ClaudeHttpProvider::CreateDescriptor(),
-                OllamaHttpServiceComponent::CreateDescriptor(),
-                OllamaModel::CreateDescriptor(),
-                OllamaChatModel::CreateDescriptor(),
-            });
+            { ClaudeModelTextCompletions::CreateDescriptor(),
+              ClaudeModelMessagesAPI::CreateDescriptor(),
+              ClaudeHttpProvider::CreateDescriptor(),
+              OllamaHttpServiceComponent::CreateDescriptor(),
+              OllamaModel::CreateDescriptor(),
+              OllamaChatModel::CreateDescriptor() });
     }
 
     AZ::ComponentTypeList GenAIVendorBundleModuleInterface::GetRequiredSystemComponents() const

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelConfiguration.cpp
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelConfiguration.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "ClaudeModelConfiguration.h"
+
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
@@ -133,12 +134,12 @@ namespace GenAIVendorBundle
         AZStd::string lowerCaseParameterName = AZStd::tolower(parameterValue);
 
         lowerCaseParameterName.erase(
-            std::remove_if(
+            AZStd::remove_if(
                 lowerCaseParameterName.begin(),
                 lowerCaseParameterName.end(),
                 [](unsigned char c)
                 {
-                    return std::isspace(c);
+                    return AZStd::isspace(c);
                 }),
             lowerCaseParameterName.end());
 

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelConfiguration.h
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelConfiguration.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <GenAIVendorBundle/GenAIVendorBundleTypeIds.h>
+
 #include <AzCore/Component/Component.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/RTTI/ReflectContext.h>
@@ -19,7 +21,7 @@ namespace GenAIVendorBundle
     class ClaudeModelConfiguration : public AZ::ComponentConfig
     {
     public:
-        AZ_RTTI(ClaudeModelConfiguration, "{5a478ab3-8ac6-4c23-8768-03c2791d6b11}");
+        AZ_RTTI(ClaudeModelConfiguration, ClaudeModelConfigurationTypeId);
         AZ_CLASS_ALLOCATOR(ClaudeModelConfiguration, AZ::SystemAllocator);
 
         ClaudeModelConfiguration() = default;
@@ -76,6 +78,5 @@ namespace GenAIVendorBundle
         const static AZStd::map<AZStd::string_view, Parameters> m_parameterNameToEnum;
 
         AZ::Outcome<void, AZStd::string> SetModelParameter(const AZ::Name& parameterName, const AZStd::string& parameterValue);
-
-    }; // namespace GenAIVendorBundle
+    };
 } // namespace GenAIVendorBundle

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelMessagesAPI.cpp
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelMessagesAPI.cpp
@@ -8,16 +8,13 @@
 
 #include "ClaudeModelMessagesAPI.h"
 #include "ClaudeModelConfiguration.h"
+#include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
 
-#include <AzCore/Component/Component.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/std/containers/vector.h>
-#include <AzCore/std/string/string.h>
-#include <AzCore/std/utility/pair.h>
-#include <GenAIFramework/Communication/AIModelRequestBus.h>
-#include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
+
 #include <aws/core/utils/Array.h>
 #include <aws/core/utils/json/JsonSerializer.h>
 #include <aws/core/utils/memory/stl/AWSVector.h>

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelMessagesAPI.h
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelMessagesAPI.h
@@ -9,10 +9,11 @@
 #pragma once
 
 #include "ClaudeModelConfiguration.h"
+#include <GenAIFramework/Communication/AIModelRequestBus.h>
+
 #include <AzCore/Component/Component.h>
 #include <AzCore/std/string/string.h>
-#include <AzCore/std/utility/pair.h>
-#include <GenAIFramework/Communication/AIModelRequestBus.h>
+
 #include <aws/core/utils/json/JsonSerializer.h>
 
 namespace GenAIVendorBundle
@@ -22,7 +23,7 @@ namespace GenAIVendorBundle
         , public GenAIFramework::AIModelRequestBus::Handler
     {
     public:
-        AZ_COMPONENT(ClaudeModelMessagesAPI, "{9ffed8c5-a872-4adf-bc80-74ba1fe92e95}");
+        AZ_COMPONENT(ClaudeModelMessagesAPI, ClaudeModelMessagesAPITypeId);
 
         static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelTextCompletions.cpp
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelTextCompletions.cpp
@@ -8,13 +8,15 @@
 
 #include "ClaudeModelTextCompletions.h"
 #include "ClaudeModelConfiguration.h"
+#include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
+
 #include <AzCore/Component/Component.h>
 #include <AzCore/RTTI/RTTIMacros.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/any.h>
-#include <GenAIFramework/Communication/AIModelRequestBus.h>
-#include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
+
 #include <aws/core/utils/json/JsonSerializer.h>
 #include <sstream>
 

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelTextCompletions.h
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Claude/ClaudeModelTextCompletions.h
@@ -9,8 +9,12 @@
 #pragma once
 
 #include "ClaudeModelConfiguration.h"
-#include <AzCore/Component/Component.h>
 #include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIVendorBundle/GenAIVendorBundleTypeIds.h>
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/std/string/string.h>
+
 #include <aws/core/utils/json/JsonSerializer.h>
 
 namespace GenAIVendorBundle
@@ -20,7 +24,7 @@ namespace GenAIVendorBundle
         , public GenAIFramework::AIModelRequestBus::Handler
     {
     public:
-        AZ_COMPONENT(ClaudeModelTextCompletions, "{0310426d-3035-4240-b9e5-d1556af98b47}");
+        AZ_COMPONENT(ClaudeModelTextCompletions, ClaudeModelTextCompletionsTypeId);
 
         static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaChatModel.cpp
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaChatModel.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "OllamaChatModel.h"
-
 #include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
 
 #include <AzCore/Component/Component.h>

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaChatModel.h
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaChatModel.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIVendorBundle/GenAIVendorBundleTypeIds.h>
 
 #include <AzCore/Component/Component.h>
 #include <AzFramework/Components/ComponentAdapter.h>
@@ -18,7 +19,7 @@ namespace GenAIVendorBundle
     class OllamaChatModelConfiguration : public AZ::ComponentConfig
     {
     public:
-        AZ_RTTI(OllamaChatModelConfiguration, "{ce2d1912-94ee-4bcd-9015-e118900f4051}");
+        AZ_RTTI(OllamaChatModelConfiguration, OllamaChatModelConfigurationTypeId);
         OllamaChatModelConfiguration() = default;
         ~OllamaChatModelConfiguration() = default;
 
@@ -39,7 +40,7 @@ namespace GenAIVendorBundle
         , public GenAIFramework::AIModelRequestBus::Handler
     {
     public:
-        AZ_COMPONENT(OllamaChatModel, "{e82c0c54-0658-419a-8170-033ef06aea96}", AZ::Component);
+        AZ_COMPONENT(OllamaChatModel, OllamaChatModelTypeId, AZ::Component);
 
         OllamaChatModel() = default;
         OllamaChatModel(const OllamaChatModelConfiguration& other);

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaModel.cpp
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaModel.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "OllamaModel.h"
-
 #include <GenAIFramework/Communication/AIModelRequestBus.h>
 #include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
 

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaModel.h
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaModel.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <GenAIFramework/Communication/AIModelRequestBus.h>
+#include <GenAIVendorBundle/GenAIVendorBundleTypeIds.h>
 
 #include <AzCore/Component/Component.h>
 #include <AzFramework/Components/ComponentAdapter.h>
@@ -18,7 +19,7 @@ namespace GenAIVendorBundle
     class OllamaModelConfiguration : public AZ::ComponentConfig
     {
     public:
-        AZ_RTTI(OllamaModelConfiguration, "{c5fa34ff-2bbb-4df4-9aa2-c27320b57f93}");
+        AZ_RTTI(OllamaModelConfiguration, OllamaModelConfigurationTypeId);
         OllamaModelConfiguration() = default;
         ~OllamaModelConfiguration() = default;
 
@@ -44,7 +45,7 @@ namespace GenAIVendorBundle
         , public GenAIFramework::AIModelRequestBus::Handler
     {
     public:
-        AZ_COMPONENT(OllamaModel, "{3782988d-058f-4943-9862-874ebc90a240}", AZ::Component);
+        AZ_COMPONENT(OllamaModel, OllamaModelTypeId, AZ::Component);
 
         OllamaModel() = default;
         OllamaModel(const OllamaModelConfiguration& other);

--- a/Gems/GenAIVendorBundle/Code/Source/Providers/Claude/ClaudeHttpProvider.cpp
+++ b/Gems/GenAIVendorBundle/Code/Source/Providers/Claude/ClaudeHttpProvider.cpp
@@ -7,23 +7,22 @@
  */
 
 #include "ClaudeHttpProvider.h"
+#include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/string/string.h>
-#include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
 #include <HttpRequestor/HttpRequestorBus.h>
 #include <HttpRequestor/HttpTypes.h>
+
 #include <aws/core/client/ClientConfiguration.h>
-#include <cstdlib>
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
 namespace GenAIVendorBundle
 {
-
     void ClaudeHttpProviderConfiguration::Reflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))

--- a/Gems/GenAIVendorBundle/Code/Source/Providers/Claude/ClaudeHttpProvider.h
+++ b/Gems/GenAIVendorBundle/Code/Source/Providers/Claude/ClaudeHttpProvider.h
@@ -8,17 +8,19 @@
 
 #pragma once
 
+#include <GenAIFramework/Communication/AIServiceProviderBus.h>
+#include <GenAIVendorBundle/GenAIVendorBundleTypeIds.h>
+
 #include <AzCore/Component/Component.h>
 #include <AzCore/std/string/string.h>
 #include <AzFramework/Components/ComponentAdapter.h>
-#include <GenAIFramework/Communication/AIServiceProviderBus.h>
 
 namespace GenAIVendorBundle
 {
     class ClaudeHttpProviderConfiguration : public AZ::ComponentConfig
     {
     public:
-        AZ_RTTI(ClaudeHttpProviderConfiguration, "{4822d5ec-f30a-4402-9fce-48826b3183bf}");
+        AZ_RTTI(ClaudeHttpProviderConfiguration, ClaudeHttpProviderConfigurationTypeId);
 
         ClaudeHttpProviderConfiguration();
         ~ClaudeHttpProviderConfiguration() = default;
@@ -41,7 +43,7 @@ namespace GenAIVendorBundle
 
     {
     public:
-        AZ_COMPONENT(ClaudeHttpProvider, "{ffa395bc-1d5b-46e3-b557-10ff550cfb34}", AZ::Component)
+        AZ_COMPONENT(ClaudeHttpProvider, ClaudeHttpProviderTypeId, AZ::Component)
 
         ClaudeHttpProvider() = default;
         ClaudeHttpProvider(const ClaudeHttpProviderConfiguration& config);

--- a/Gems/GenAIVendorBundle/Code/Source/Providers/Ollama/OllamaHttpProvider.cpp
+++ b/Gems/GenAIVendorBundle/Code/Source/Providers/Ollama/OllamaHttpProvider.cpp
@@ -12,7 +12,6 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/std/string/string.h>
 #include <HttpRequestor/HttpRequestorBus.h>
 #include <HttpRequestor/HttpTypes.h>
 

--- a/Gems/GenAIVendorBundle/Code/Source/Providers/Ollama/OllamaHttpProvider.h
+++ b/Gems/GenAIVendorBundle/Code/Source/Providers/Ollama/OllamaHttpProvider.h
@@ -9,8 +9,10 @@
 #pragma once
 
 #include <GenAIFramework/Communication/AIServiceProviderBus.h>
+#include <GenAIVendorBundle/GenAIVendorBundleTypeIds.h>
 
 #include <AzCore/Component/Component.h>
+#include <AzCore/std/string/string.h>
 #include <AzFramework/Components/ComponentAdapter.h>
 
 namespace GenAIVendorBundle
@@ -18,14 +20,14 @@ namespace GenAIVendorBundle
     class OllamaHttpServiceConfiguration : public AZ::ComponentConfig
     {
     public:
-        AZ_RTTI(OllamaHttpServiceConfiguration, "{18ddba8f-1fe5-4dde-a0f4-90dccbda5f33}");
+        AZ_RTTI(OllamaHttpServiceConfiguration, OllamaHttpServiceConfigurationTypeId);
 
         OllamaHttpServiceConfiguration() = default;
         ~OllamaHttpServiceConfiguration() = default;
 
         static void Reflect(AZ::ReflectContext* context);
 
-        AZStd::string m_url = "";
+        AZStd::string m_url = "http://localhost:11434/api/generate";
         AZStd::string m_contentType = "application/json";
         int m_timeout = 10000;
     };
@@ -36,7 +38,7 @@ namespace GenAIVendorBundle
 
     {
     public:
-        AZ_COMPONENT(OllamaHttpServiceComponent, "{aad62d35-c628-4141-b759-0d3764013b29}", AZ::Component)
+        AZ_COMPONENT(OllamaHttpServiceComponent, OllamaHttpServiceComponentTypeId, AZ::Component)
 
         OllamaHttpServiceComponent() = default;
         OllamaHttpServiceComponent(const OllamaHttpServiceConfiguration& config);

--- a/Gems/GenAIVendorBundle/Code/Source/Utils/StringManipulation.h
+++ b/Gems/GenAIVendorBundle/Code/Source/Utils/StringManipulation.h
@@ -11,7 +11,7 @@ namespace GenAIVendorBundle::Utils
         output.reserve(input.size());
         for (const char c : input)
         {
-            if (!std::isspace(c))
+            if (!AZStd::isspace(c))
             {
                 output.push_back(c);
             }
@@ -22,22 +22,22 @@ namespace GenAIVendorBundle::Utils
     inline AZ::Outcome<bool, void> GetBooleanValue(const AZStd::string& value)
     {
         AZStd::string lowerCaseParameterValue = value;
-        std::transform(
+        AZStd::transform(
             lowerCaseParameterValue.begin(),
             lowerCaseParameterValue.end(),
             lowerCaseParameterValue.begin(),
             [](unsigned char c)
             {
-                return std::tolower(c);
+                return AZStd::tolower(c);
             });
 
         lowerCaseParameterValue.erase(
-            std::remove_if(
+            AZStd::remove_if(
                 lowerCaseParameterValue.begin(),
                 lowerCaseParameterValue.end(),
                 [](unsigned char c)
                 {
-                    return std::isspace(c);
+                    return AZStd::isspace(c);
                 }),
             lowerCaseParameterValue.end());
         if (lowerCaseParameterValue == "true")


### PR DESCRIPTION
Code cleaning before the release:
- soft includes into framework/o3de/other groups
- move uuid identifiers of all components into a separate header files
- fix license
- clang-format