### PR TITLE
Rename OllamaModel -> OllamaGenerateModel

### DIFF
--- a/Gems/GenAIVendorBundle/Code/Include/GenAIVendorBundle/GenAIVendorBundleTypeIds.h
+++ b/Gems/GenAIVendorBundle/Code/Include/GenAIVendorBundle/GenAIVendorBundleTypeIds.h
@@ -26,8 +26,8 @@ namespace GenAIVendorBundle
     inline constexpr const char* ClaudeModelTextCompletionsTypeId = "{0310426D-3035-4240-B9E5-D1556AF98B47}";
     inline constexpr const char* OllamaChatModelConfigurationTypeId = "{CE2D1912-94EE-4BCD-9015-E118900F4051}";
     inline constexpr const char* OllamaChatModelTypeId = "{E82C0C54-0658-419A-8170-033EF06AEA96}";
-    inline constexpr const char* OllamaModelConfigurationTypeId = "{C5FA34FF-2BBB-4DF4-9AA2-C27320B57F93}";
-    inline constexpr const char* OllamaModelTypeId = "{3782988D-058F-4943-9862-874EBC90A240}";
+    inline constexpr const char* OllamaGenerateModelConfigurationTypeId = "{C5FA34FF-2BBB-4DF4-9AA2-C27320B57F93}";
+    inline constexpr const char* OllamaGenerateModelTypeId = "{3782988D-058F-4943-9862-874EBC90A240}";
 
     // Providers TypeIds
     inline constexpr const char* ClaudeHttpProviderConfigurationTypeId = "{4822D5EC-F30A-4402-9FCE-48826B3183BF}";

--- a/Gems/GenAIVendorBundle/Code/Source/GenAIVendorBundleModuleInterface.cpp
+++ b/Gems/GenAIVendorBundle/Code/Source/GenAIVendorBundleModuleInterface.cpp
@@ -11,7 +11,7 @@
 #include <Models/Claude/ClaudeModelMessagesAPI.h>
 #include <Models/Claude/ClaudeModelTextCompletions.h>
 #include <Models/Ollama/OllamaChatModel.h>
-#include <Models/Ollama/OllamaModel.h>
+#include <Models/Ollama/OllamaGenerateModel.h>
 #include <Providers/Claude/ClaudeHttpProvider.h>
 #include <Providers/Ollama/OllamaHttpProvider.h>
 
@@ -35,7 +35,7 @@ namespace GenAIVendorBundle
               ClaudeModelMessagesAPI::CreateDescriptor(),
               ClaudeHttpProvider::CreateDescriptor(),
               OllamaHttpServiceComponent::CreateDescriptor(),
-              OllamaModel::CreateDescriptor(),
+              OllamaGenerateModel::CreateDescriptor(),
               OllamaChatModel::CreateDescriptor() });
     }
 

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaGenerateModel.cpp
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaGenerateModel.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include "OllamaModel.h"
+#include "OllamaGenerateModel.h"
 #include <GenAIFramework/Communication/AIModelRequestBus.h>
 #include <GenAIFramework/SystemRegistrationContext/SystemRegistrationContext.h>
 
@@ -19,104 +19,105 @@
 namespace GenAIVendorBundle
 {
 
-    void OllamaModelConfiguration::Reflect(AZ::ReflectContext* context)
+    void OllamaGenerateModelConfiguration::Reflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<OllamaModelConfiguration, AZ::ComponentConfig>()
+            serializeContext->Class<OllamaGenerateModelConfiguration, AZ::ComponentConfig>()
                 ->Version(0)
-                ->Field("Model", &OllamaModelConfiguration::m_model)
-                ->Field("Format", &OllamaModelConfiguration::m_format)
-                ->Field("Options", &OllamaModelConfiguration::m_options)
-                ->Field("System", &OllamaModelConfiguration::m_system)
-                ->Field("Template", &OllamaModelConfiguration::m_template)
-                ->Field("Stream", &OllamaModelConfiguration::m_stream)
-                ->Field("Raw", &OllamaModelConfiguration::m_raw)
-                ->Field("KeepAlive", &OllamaModelConfiguration::m_keepAlive)
-                ->Field("useDefaultFormat", &OllamaModelConfiguration::m_useDefaultFormat)
-                ->Field("useDefaultOptions", &OllamaModelConfiguration::m_useDefaultOptions)
-                ->Field("useDefaultSystem", &OllamaModelConfiguration::m_useDefaultSystem)
-                ->Field("useDefaultTemplate", &OllamaModelConfiguration::m_useDefaultTemplate)
-                ->Field("useDefaultKeepAlive", &OllamaModelConfiguration::m_useDefaultKeepAlive);
+                ->Field("Model", &OllamaGenerateModelConfiguration::m_model)
+                ->Field("Format", &OllamaGenerateModelConfiguration::m_format)
+                ->Field("Options", &OllamaGenerateModelConfiguration::m_options)
+                ->Field("System", &OllamaGenerateModelConfiguration::m_system)
+                ->Field("Template", &OllamaGenerateModelConfiguration::m_template)
+                ->Field("Stream", &OllamaGenerateModelConfiguration::m_stream)
+                ->Field("Raw", &OllamaGenerateModelConfiguration::m_raw)
+                ->Field("KeepAlive", &OllamaGenerateModelConfiguration::m_keepAlive)
+                ->Field("useDefaultFormat", &OllamaGenerateModelConfiguration::m_useDefaultFormat)
+                ->Field("useDefaultOptions", &OllamaGenerateModelConfiguration::m_useDefaultOptions)
+                ->Field("useDefaultSystem", &OllamaGenerateModelConfiguration::m_useDefaultSystem)
+                ->Field("useDefaultTemplate", &OllamaGenerateModelConfiguration::m_useDefaultTemplate)
+                ->Field("useDefaultKeepAlive", &OllamaGenerateModelConfiguration::m_useDefaultKeepAlive);
 
             if (auto editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<OllamaModelConfiguration>("Ollama Model Configuration", "Configuration for the Ollama model")
+                editContext->Class<OllamaGenerateModelConfiguration>("Ollama Model Configuration", "Configuration for the Ollama model")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "AI")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &OllamaModelConfiguration::m_model, "Model", "Model to use for the prompt")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &OllamaGenerateModelConfiguration::m_model, "Model", "Model to use for the prompt")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &OllamaModelConfiguration::m_format,
+                        &OllamaGenerateModelConfiguration::m_format,
                         "Format",
                         "The format to return a response in. Currently the only accepted value is json")
-                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &OllamaModelConfiguration::m_useDefaultFormat)
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &OllamaGenerateModelConfiguration::m_useDefaultFormat)
                     ->DataElement(
                         AZ::Edit::UIHandlers::MultiLineEdit,
-                        &OllamaModelConfiguration::m_options,
+                        &OllamaGenerateModelConfiguration::m_options,
                         "Options",
                         "Additional model parameters listed in the documentation for the Modelfile such as temperature")
-                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &OllamaModelConfiguration::m_useDefaultOptions)
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &OllamaGenerateModelConfiguration::m_useDefaultOptions)
                     ->DataElement(
                         AZ::Edit::UIHandlers::MultiLineEdit,
-                        &OllamaModelConfiguration::m_system,
+                        &OllamaGenerateModelConfiguration::m_system,
                         "System",
                         "System message to (overrides what is defined in the Modelfile)")
-                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &OllamaModelConfiguration::m_useDefaultSystem)
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &OllamaGenerateModelConfiguration::m_useDefaultSystem)
                     ->DataElement(
                         AZ::Edit::UIHandlers::MultiLineEdit,
-                        &OllamaModelConfiguration::m_template,
+                        &OllamaGenerateModelConfiguration::m_template,
                         "Template",
                         "The prompt template to use (overrides what is defined in the Modelfile)")
-                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &OllamaModelConfiguration::m_useDefaultTemplate)
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &OllamaGenerateModelConfiguration::m_useDefaultTemplate)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &OllamaModelConfiguration::m_stream,
+                        &OllamaGenerateModelConfiguration::m_stream,
                         "Stream (disabled as only false is supported)",
                         "If false the response will be returned as a single response object, rather than a stream of objects. Currently "
                         "the only accepted value is false")
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &OllamaModelConfiguration::m_raw,
+                        &OllamaGenerateModelConfiguration::m_raw,
                         "Raw (disabled)",
                         "If true no formatting will be applied to the prompt. You may choose to use the raw parameter if you are "
                         "specifying a full templated prompt in your request to the API")
                     ->Attribute(AZ::Edit::Attributes::ReadOnly, true)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &OllamaModelConfiguration::m_keepAlive,
+                        &OllamaGenerateModelConfiguration::m_keepAlive,
                         "Keep Alive",
                         "Controls how long the model will stay loaded into memory following the request (default: 5m)")
-                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &OllamaModelConfiguration::m_useDefaultKeepAlive)
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &OllamaGenerateModelConfiguration::m_useDefaultKeepAlive)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &OllamaModelConfiguration::m_useDefaultFormat,
+                        &OllamaGenerateModelConfiguration::m_useDefaultFormat,
                         "Use Default Format",
                         "Use the default format")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &OllamaModelConfiguration::m_useDefaultOptions,
+                        &OllamaGenerateModelConfiguration::m_useDefaultOptions,
                         "Use Default Options",
                         "Use the default options")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &OllamaModelConfiguration::m_useDefaultSystem,
+                        &OllamaGenerateModelConfiguration::m_useDefaultSystem,
                         "Use Default System",
                         "Use the default system")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &OllamaModelConfiguration::m_useDefaultTemplate,
+                        &OllamaGenerateModelConfiguration::m_useDefaultTemplate,
                         "Use Default Template",
                         "Use the default template")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &OllamaModelConfiguration::m_useDefaultKeepAlive,
+                        &OllamaGenerateModelConfiguration::m_useDefaultKeepAlive,
                         "Use Default Keep Alive",
                         "Use the default keep alive")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues);
@@ -124,28 +125,30 @@ namespace GenAIVendorBundle
         }
     }
 
-    OllamaModel::OllamaModel(const OllamaModelConfiguration& config)
+    OllamaGenerateModel::OllamaGenerateModel(const OllamaGenerateModelConfiguration& config)
         : m_configuration(config)
     {
     }
 
-    void OllamaModel::Reflect(AZ::ReflectContext* context)
+    void OllamaGenerateModel::Reflect(AZ::ReflectContext* context)
     {
-        OllamaModelConfiguration::Reflect(context);
+        OllamaGenerateModelConfiguration::Reflect(context);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<OllamaModel, AZ::Component>()->Version(0)->Field("Configuration", &OllamaModel::m_configuration);
+            serializeContext->Class<OllamaGenerateModel, AZ::Component>()->Version(0)->Field(
+                "Configuration", &OllamaGenerateModel::m_configuration);
 
             if (auto editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<OllamaModel>("Ollama Model", "Generates prompts and extracts results for the Ollama model")
+                editContext
+                    ->Class<OllamaGenerateModel>("Ollama Generate Model", "Generates prompts and extracts results for the Ollama model")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Ollama")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &OllamaModel::m_configuration,
+                        &OllamaGenerateModel::m_configuration,
                         "Configuration",
                         "The configuration attached to the prompts")
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
@@ -154,21 +157,21 @@ namespace GenAIVendorBundle
 
         if (auto registrationContext = azrtti_cast<GenAIFramework::SystemRegistrationContext*>(context))
         {
-            registrationContext->RegisterModelConfiguration<OllamaModel>();
+            registrationContext->RegisterModelConfiguration<OllamaGenerateModel>();
         }
     }
 
-    void OllamaModel::Activate()
+    void OllamaGenerateModel::Activate()
     {
         GenAIFramework::AIModelRequestBus::Handler::BusConnect(GetEntityId());
     }
 
-    void OllamaModel::Deactivate()
+    void OllamaGenerateModel::Deactivate()
     {
         GenAIFramework::AIModelRequestBus::Handler::BusDisconnect();
     }
 
-    GenAIFramework::ModelAPIRequest OllamaModel::PrepareRequest(const GenAIFramework::AIMessages& prompt)
+    GenAIFramework::ModelAPIRequest OllamaGenerateModel::PrepareRequest(const GenAIFramework::AIMessages& prompt)
     {
         Aws::Utils::Json::JsonValue jsonRequest;
         AZStd::string systemMessage = "";
@@ -233,7 +236,7 @@ namespace GenAIVendorBundle
         return jsonRequest.View().WriteReadable().c_str();
     }
 
-    GenAIFramework::ModelAPIExtractedResponse OllamaModel::ExtractResult(const GenAIFramework::ModelAPIResponse& modelAPIResponse)
+    GenAIFramework::ModelAPIExtractedResponse OllamaGenerateModel::ExtractResult(const GenAIFramework::ModelAPIResponse& modelAPIResponse)
     {
         if (!modelAPIResponse.IsSuccess())
         {

--- a/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaGenerateModel.h
+++ b/Gems/GenAIVendorBundle/Code/Source/Models/Ollama/OllamaGenerateModel.h
@@ -16,12 +16,12 @@
 
 namespace GenAIVendorBundle
 {
-    class OllamaModelConfiguration : public AZ::ComponentConfig
+    class OllamaGenerateModelConfiguration : public AZ::ComponentConfig
     {
     public:
-        AZ_RTTI(OllamaModelConfiguration, OllamaModelConfigurationTypeId);
-        OllamaModelConfiguration() = default;
-        ~OllamaModelConfiguration() = default;
+        AZ_RTTI(OllamaGenerateModelConfiguration, OllamaGenerateModelConfigurationTypeId);
+        OllamaGenerateModelConfiguration() = default;
+        ~OllamaGenerateModelConfiguration() = default;
 
         static void Reflect(AZ::ReflectContext* context);
 
@@ -40,16 +40,16 @@ namespace GenAIVendorBundle
         bool m_useDefaultKeepAlive = true;
     };
 
-    class OllamaModel
+    class OllamaGenerateModel
         : public AZ::Component
         , public GenAIFramework::AIModelRequestBus::Handler
     {
     public:
-        AZ_COMPONENT(OllamaModel, OllamaModelTypeId, AZ::Component);
+        AZ_COMPONENT(OllamaGenerateModel, OllamaGenerateModelTypeId, AZ::Component);
 
-        OllamaModel() = default;
-        OllamaModel(const OllamaModelConfiguration& other);
-        ~OllamaModel() = default;
+        OllamaGenerateModel() = default;
+        OllamaGenerateModel(const OllamaGenerateModelConfiguration& other);
+        ~OllamaGenerateModel() = default;
 
         static void Reflect(AZ::ReflectContext* context);
 
@@ -66,6 +66,6 @@ namespace GenAIVendorBundle
         GenAIFramework::ModelAPIExtractedResponse ExtractResult(const GenAIFramework::ModelAPIResponse& modelAPIResponse) override;
         //////////////////////////////////////////////////////////////////////////
 
-        OllamaModelConfiguration m_configuration;
+        OllamaGenerateModelConfiguration m_configuration;
     };
 } // namespace GenAIVendorBundle

--- a/Gems/GenAIVendorBundle/Code/genaivendorbundle_private_files.cmake
+++ b/Gems/GenAIVendorBundle/Code/genaivendorbundle_private_files.cmake
@@ -5,8 +5,8 @@ set(FILES
 
     Source/Providers/Ollama/OllamaHttpProvider.cpp
     Source/Providers/Ollama/OllamaHttpProvider.h
-    Source/Models/Ollama/OllamaModel.cpp
-    Source/Models/Ollama/OllamaModel.h
+    Source/Models/Ollama/OllamaGenerateModel.cpp
+    Source/Models/Ollama/OllamaGenerateModel.h
     Source/Models/Ollama/OllamaChatModel.cpp
     Source/Models/Ollama/OllamaChatModel.h
 


### PR DESCRIPTION
Closes #135 

I've change the name of the OllamaModel to the OllamaGenerateModel to better reflect the naming convention in https://github.com/ollama/ollama?tab=readme-ov-file#rest-api.