### PR TITLE
Fix Apache 2.0 license after incorrect merge PR

### DIFF
--- a/LICENSE_APACHE2.TXT
+++ b/LICENSE_APACHE2.TXT
@@ -1,4 +1,3 @@
-<<<<<<<< HEAD:LICENSE_APACHE2.TXT
                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -200,32 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-========
-OPEN 3D ENGINE LICENSING
-The default license for Open 3D Engine is the Apache License, Version 2.0 
-(see LICENSE_APACHE2.TXT); you may elect at your option to use the Open 3D 
-Engine under the MIT License (see LICENSE_MIT.TXT). Contributions must be 
-made under both licenses.
- 
-THIRD PARTY COMPONENTS
-Open 3D Engine requires the use of (and in some cases makes available to you) 
-software and assets that have been developed by third parties and are subject 
-to separate license terms (such as code licensed under other open source 
-licenses). It is your responsibility to comply with the applicable licenses. 
-Information on third party materials, and the applicable license terms, are 
-referenced in or included with the materials, such as in separate LICENSE.txt 
-files accompanying the materials.
- 
-Please note that certain materials are subject to "copyleft" licenses, which 
-require distribution of source code, including:
- 
-- Qt Toolkit https://github.com/qtproject/, which is subject to the GNU 
-Lesser General Public License version 3 (with certain exceptions). A copy of 
-the source code for Qt Toolkit may be found at 
-https://github.com/o3de/3p-package-source/tree/main/package-system/Qt 
- 
-- The AWS Python SDK uses Chardet https://chardet.github.io/, which is 
-subject to the GNU Lesser General Public License version 2.1. A copy of the 
-source code may be found at https://github.com/chardet/chardet.
- 
->>>>>>>> main:LICENSE


### PR DESCRIPTION
Merge PR left unsolved conflict in the license file. This is fixed in this PR.